### PR TITLE
[bugfix] Fixes issue with Optional parsing for Metric class

### DIFF
--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -217,9 +217,12 @@ def _get_parser(
                 return types.make_enum_parser(type_)
             elif types.is_constructible_from_str(type_):
                 return functools.partial(type_)
+            elif isinstance(type_, type(type(None))):
+                return functools.partial(types.none_parser)
             elif types.get_origin_type(type_) is Union:
                 return types.make_union_parser(
-                    type_, [_get_parser(cls, arg, parsers) for arg in types.get_arg_types(type_)]
+                    union=type_,
+                    parsers=[_get_parser(cls, arg, parsers) for arg in types.get_arg_types(type_)],
                 )
             elif types.get_origin_type(type_) is Literal:  # Py>=3.7.
                 return types.make_literal_parser(
@@ -272,7 +275,7 @@ def attr_from(
             if not set_value:
                 try:
                     parser = _get_parser(cls=cls, type_=attribute.type, parsers=parsers)
-                    return_value = parser.func(str_value)
+                    return_value = parser(str_value)
                     set_value = True
                 except Exception:
                     pass

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -1,6 +1,6 @@
 import enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -26,6 +26,10 @@ class DummyMetric(Metric["DummyMetric"]):
     str_value: str
     bool_val: bool
     enum_val: EnumTest = attr.ib()
+    optional_str_value: Optional[str] = attr.ib()
+    optional_int_value: Optional[int] = attr.ib()
+    optional_bool_value: Optional[bool] = attr.ib()
+    optional_enum_value: Optional[EnumTest] = attr.ib()
     dict_value: Dict[int, str] = attr.ib()
     tuple_value: Tuple[int, str] = attr.ib()
     list_value: List[str] = attr.ib()
@@ -44,6 +48,10 @@ DUMMY_METRICS: List[DummyMetric] = [
         str_value="2",
         bool_val=True,
         enum_val=EnumTest.EnumVal1,
+        optional_str_value="test4",
+        optional_int_value=-5,
+        optional_bool_value=True,
+        optional_enum_value=EnumTest.EnumVal3,
         dict_value={
             1: "test1",
         },
@@ -56,6 +64,10 @@ DUMMY_METRICS: List[DummyMetric] = [
         str_value="2",
         bool_val=False,
         enum_val=EnumTest.EnumVal2,
+        optional_str_value="test",
+        optional_int_value=1,
+        optional_bool_value=False,
+        optional_enum_value=EnumTest.EnumVal1,
         dict_value={2: "test2", 7: "test4"},
         tuple_value=(1, "test2"),
         list_value=["1"],
@@ -66,6 +78,10 @@ DUMMY_METRICS: List[DummyMetric] = [
         str_value="2",
         bool_val=False,
         enum_val=EnumTest.EnumVal3,
+        optional_str_value=None,
+        optional_int_value=None,
+        optional_bool_value=None,
+        optional_enum_value=None,
         dict_value={},
         tuple_value=(2, "test3"),
         list_value=["1", "2", "3"],
@@ -135,6 +151,10 @@ def test_metric_header() -> None:
         "str_value",
         "bool_val",
         "enum_val",
+        "optional_str_value",
+        "optional_int_value",
+        "optional_bool_value",
+        "optional_enum_value",
         "dict_value",
         "tuple_value",
         "list_value",


### PR DESCRIPTION
Following bugfixes:
- Optional parsing was running into issues because the NoneType had no parser, which was leading to Exceptions that were being hidden by error handling. This resolves that issue
- several imports were running into issues because the functions didn't exist as named or were private. This was also being caught by error handling and therefore not causing CI issues. This resolves that issue.
- Parsing was using `partial.func`, rather than directly calling the partial, which was leading to errors that were, again, being caught by error handling. This resolves that issue.

Features:
- adds an `is_optional` function to check if a type is optional
- supports optional parsing more robustly


Also adds tests for these problems