### PR TITLE
Remove square brackets when writing lists to disk

### DIFF
--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -118,10 +118,10 @@ def _get_parser(
                 return functools.partial(
                     lambda s: origin_type(
                         []
-                        if s == "[]"
+                        if s == ""
                         else [
                             subtype_parser(item)
-                            for item in origin_type(split_at_given_level(s[1:-1], split_delim=","))
+                            for item in origin_type(split_at_given_level(s, split_delim=","))
                         ]
                     )
                 )

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -225,9 +225,9 @@ class Metric(ABC, Generic[MetricType]):
                 return "(" + ",".join(cls.format_value(v) for v in value) + ")"
         if isinstance(value, (list)):
             if len(value) == 0:
-                return "[]"
+                return ""
             else:
-                return "[" + ",".join(cls.format_value(v) for v in value) + "]"
+                return ",".join(cls.format_value(v) for v in value)
         if isinstance(value, (set)):
             if len(value) == 0:
                 return ""

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -186,11 +186,19 @@ def test_metric_custom_formatter() -> None:
     assert list(person.formatted_values()) == ["john doe", "42"]
 
 
-def test_metric_list_formatting_format() -> None:
-    assert Person(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
+@attr.s(auto_attribs=True, frozen=True)
+class ListPerson(Metric["ListPerson"]):
+    name: List[str]
+    age: List[int]
+
+
+def test_metric_list_format() -> None:
+    assert ListPerson(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
         ["Max,Sally", "43,55"]
     )
 
 
-def test_metric_list_formatting_parse() -> None:
-    assert Person.parse(fields=[["Max, Sally"], "40"]) == Person(name="['Max, Sally']", age=40)
+def test_metric_list_parse() -> None:
+    assert ListPerson.parse(fields=["Max,Sally", "43, 55"]) == ListPerson(
+        name=["Max", "Sally"], age=[43, 55]
+    )

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -186,8 +186,7 @@ def test_metric_custom_formatter() -> None:
     assert list(person.formatted_values()) == ["john doe", "42"]
 
 
-def test_metric_list_formatting_format_and_parse() -> None:
+def test_metric_list_formatting_format() -> None:
     assert Person(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
         ["Max,Sally", "43,55"]
     )
-    # TODO add parse

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -190,3 +190,7 @@ def test_metric_list_formatting_format() -> None:
     assert Person(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
         ["Max,Sally", "43,55"]
     )
+
+
+def test_metric_list_formatting_parse() -> None:
+    assert Person.parse(fields=[["Max, Sally"], "40"]) == Person(name="['Max, Sally']", age=40)

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -184,3 +184,10 @@ def test_metric_custom_parser() -> None:
 def test_metric_custom_formatter() -> None:
     person = NamedPerson(name=Name(first="john", last="doe"), age=42)
     assert list(person.formatted_values()) == ["john doe", "42"]
+
+
+def test_metric_list_formatting_format_and_parse() -> None:
+    assert Person(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
+        ["Max,Sally", "43,55"]
+    )
+    # TODO add parse


### PR DESCRIPTION
In branch `issue_10` lines were changed in `Metric.format.py()` so that empty lists are formatted as `""` and other lists do not include `[]`. Lines were also changed in `inspect.py/get_parser()` so that an empty string can be parsed as a list. 