### PR TITLE
Suppress stderr printing when sam indices are older than sam file

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -169,6 +169,7 @@ from pysam import AlignedSegment
 from pysam import AlignmentFile as SamFile
 from pysam import AlignmentHeader as SamHeader
 
+import fgpyo.io
 from fgpyo.collections import PeekableIterator
 
 SamPath = Union[IO[Any], Path, str]
@@ -259,8 +260,11 @@ def _pysam_open(
     if unmapped and open_for_reading:
         kwargs["check_sq"] = False
 
-    # Open it!
-    return pysam.AlignmentFile(path, **kwargs)
+    # Open it alignment file, suppressing stderr in case index files are older than SAM file
+    with fgpyo.io.suppress_stderr():
+        alignment_file = pysam.AlignmentFile(path, **kwargs)
+    # now restore stderr and return the alignment file
+    return alignment_file
 
 
 def reader(

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -530,7 +530,6 @@ class SamBuilder:
                 path = Path(fp.name)
 
         with NamedTemporaryFile(suffix=".bam", delete=True) as fp:
-
             with sam.writer(
                 fp.file, header=self._samheader, file_type=sam.SamFileType.BAM  # type: ignore
             ) as writer:

--- a/fgpyo/sam/tests/test_sam.py
+++ b/fgpyo/sam/tests/test_sam.py
@@ -280,9 +280,11 @@ def test_is_indel() -> None:
     indels = [op for op in CigarOp if op.is_indel]
     assert indels == [CigarOp.I, CigarOp.D]
 
+
 def test_is_clipping() -> None:
     clips = [op for op in CigarOp if op.is_clipping]
     assert clips == [CigarOp.S, CigarOp.H]
+
 
 def test_isize() -> None:
     builder = SamBuilder()

--- a/fgpyo/tests/test_read_structure.py
+++ b/fgpyo/tests/test_read_structure.py
@@ -124,7 +124,6 @@ def test_read_structure_variable_once_and_only_once_last_segment_exception(strin
 def test_read_structure_from_segments_reset_offset(
     segments: Tuple[ReadSegment, ...], expected: Tuple[ReadSegment, ...]
 ) -> None:
-
     read_structure = ReadStructure.from_segments(segments=segments, reset_offsets=True)
     assert read_structure.segments == expected
 


### PR DESCRIPTION
Merging into the [unmerged feature/add-vcf](https://github.com/fulcrumgenomics/fgpyo/pull/47) PR because it moves the `redirect_dev_null` context manager to a common location (`fgpyo.io`) so that it can be used by `vcf` and `sam` modules.

I'm actually not sure how to write unit tests for this functionality, I've weirdly not been successful in extracting text from pysam errors by redirecting to a non-dev-null file. However, I did verify in manual testing that this does what it says on the tin.