### PR TITLE
Metric.read should support skipping extra columns

### DIFF
--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -34,7 +34,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-""" Stubs for pysam imports """
+"""Stubs for pysam imports """
 if TYPE_CHECKING:
 
     def samtools_dict(*args: Any) -> None:
@@ -152,7 +152,7 @@ class FastaBuilder:
         self.__contig_builders: Dict[str, ContigBuilder] = {}
 
     def __getitem__(self, key: str) -> ContigBuilder:
-        """ Access instance of ContigBuilder by name """
+        """Access instance of ContigBuilder by name """
         return self.__contig_builders[key]
 
     def add(

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     def samtools_faidx(*args: Any) -> None:
         pass
 
-
 else:
     from pysam import dict as samtools_dict
     from pysam import faidx as samtools_faidx
@@ -152,7 +151,7 @@ class FastaBuilder:
         self.__contig_builders: Dict[str, ContigBuilder] = {}
 
     def __getitem__(self, key: str) -> ContigBuilder:
-        """Access instance of ContigBuilder by name """
+        """Access instance of ContigBuilder by name"""
         return self.__contig_builders[key]
 
     def add(

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     def samtools_faidx(*args: Any) -> None:
         pass
 
+
 else:
     from pysam import dict as samtools_dict
     from pysam import faidx as samtools_faidx

--- a/fgpyo/sam/tests/test_clipping.py
+++ b/fgpyo/sam/tests/test_clipping.py
@@ -11,7 +11,7 @@ from fgpyo.sam.builder import SamBuilder
 
 
 def r(start: Optional[int], cigar: Optional[str], strand: Optional[str] = "+") -> AlignedSegment:
-    """ "Constructs a read for testing."""
+    """Constructs a read for testing."""
     builder = SamBuilder()
     if start:
         r1, r2 = builder.add_pair(chrom="chr1", start1=start, cigar1=cigar, strand1=strand)

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -315,3 +315,8 @@ def attribute_is_optional(attribute: attr.Attribute) -> bool:
     return types.get_origin_type(attribute.type) is Union and isinstance(
         None, types.get_arg_types(attribute.type)
     )
+
+
+def attribute_has_default(attribute: attr.Attribute) -> bool:
+    """Returns True if the attribute has a default value, False otherwise"""
+    return attribute.default != attr.NOTHING or attribute_is_optional(attribute)

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -164,7 +164,7 @@ def _get_parser(
                     unpaired '{', or '}' characters
                     """
                     assert tuple_string[0] == "(", "Tuple val improperly formatted"
-                    assert tuple_string[-1] == ")", "Tuple val improprly formatted"
+                    assert tuple_string[-1] == ")", "Tuple val improperly formatted"
                     tuple_string = tuple_string[1:-1]
                     if len(tuple_string) == 0:
                         return ()
@@ -254,7 +254,13 @@ def _get_parser(
 def attr_from(
     cls: Type, kwargs: Dict[str, str], parsers: Optional[Dict[type, Callable[[str], Any]]] = None
 ) -> Any:
-    """Builds an attr class from key-word arguments"""
+    """Builds an attr class from key-word arguments
+
+    Args:
+        cls: the attr class to be built
+        kwargs: a dictionary of keyword arguments
+        parsers: a dictionary of parser functions to apply to specific types
+    """
     return_values: Dict[str, Any] = {}
     for attribute in attr.fields(cls):
         return_value: Any
@@ -267,16 +273,6 @@ def attr_from(
                 return_value = attribute.converter(str_value)
                 set_value = True
 
-            # try setting by casting
-            # Note that while bools *can* be cast from string, all non empty strings evaluate to
-            # True, because python, so we need to check for that explicitly
-            if not set_value and attribute.type is not None and not attribute.type == bool:
-                try:
-                    return_value = attribute.type(str_value)
-                    set_value = True
-                except (ValueError, TypeError):
-                    pass
-
             # try getting a known parser
             if not set_value:
                 try:
@@ -286,17 +282,36 @@ def attr_from(
                 except ParserNotFoundException:
                     pass
 
+            # try setting by casting
+            # Note that while bools *can* be cast from string, all non-empty strings evaluate to
+            # True, because python, so we need to check for that explicitly
+            if not set_value and attribute.type is not None and not attribute.type == bool:
+                try:
+                    return_value = attribute.type(str_value)
+                    set_value = True
+                except (ValueError, TypeError):
+                    pass
+
             # fail otherwise
             assert (
                 set_value
             ), f"Do not know how to convert string to {attribute.type} for value: {str_value}"
         else:  # no value, check for a default
-            assert attribute.default is not None or (
-                types.get_origin_type(attribute.type) is Union
-                and isinstance(None, types.get_arg_types(attribute.type))
+            assert attribute.default is not None or attribute_is_optional(
+                attribute
             ), f"No value given and no default for attribute `{attribute.name}`"
             return_value = attribute.default
+            # when the default is attr.NOTHING, just use None
+            if return_value is attr.NOTHING:
+                return_value = None
 
         return_values[attribute.name] = return_value
 
     return cls(**return_values)
+
+
+def attribute_is_optional(attribute: attr.Attribute) -> bool:
+    """Returns True if the attribute is optional, False otherwise"""
+    return types.get_origin_type(attribute.type) is Union and isinstance(
+        None, types.get_arg_types(attribute.type)
+    )

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -169,17 +169,18 @@ class Metric(ABC, Generic[MetricType]):
             missing_from_class = file_fields.difference(class_fields)
             missing_from_file = class_fields.difference(file_fields)
 
-            # ignore optional class fields that are missing from the file (via header), they'll get
-            # a default of None
+            field_name_to_attribute = attr.fields_dict(cls)
+
+            # ignore class fields that are missing from the file (via header) if they're optional
+            # or have a default
             if len(missing_from_file) > 0:
-                field_name_to_attribute = attr.fields_dict(cls)
-                missing_from_file_optionals = [
+                fields_with_defaults = [
                     field
                     for field in missing_from_file
-                    if inspect.attribute_is_optional(field_name_to_attribute[field])
+                    if inspect.attribute_has_default(field_name_to_attribute[field])
                 ]
                 # remove optional class fields from the fields
-                missing_from_file = missing_from_file.difference(missing_from_file_optionals)
+                missing_from_file = missing_from_file.difference(fields_with_defaults)
 
             # raise an exception if there are non-optional class fields missing from the file
             if len(missing_from_file) > 0:

--- a/fgpyo/util/tests/test_inspect.py
+++ b/fgpyo/util/tests/test_inspect.py
@@ -1,0 +1,35 @@
+from fgpyo.util.inspect import attribute_is_optional
+from fgpyo.util.inspect import attr_from
+
+import attr
+from typing import Optional
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class Name:
+    required: str
+    custom_parser: str
+    optional_no_default: Optional[str]
+    optional_with_default_none: Optional[str] = None
+    optional_with_default_some: Optional[str] = "foo"
+
+
+def test_attr_from() -> None:
+    name = attr_from(
+        cls=Name,
+        kwargs={"required": "required", "custom_parser": "before"},
+        parsers={str: lambda value: "after" if value == "before" else value},
+    )
+    assert name.required == "required"
+    assert name.custom_parser == "after"
+    assert name.optional_no_default is None
+    assert name.optional_with_default_none is None
+    assert name.optional_with_default_some == "foo"
+
+
+def test_attribute_is_optional() -> None:
+    fields_dict = attr.fields_dict(Name)
+    assert not attribute_is_optional(fields_dict["required"])
+    assert attribute_is_optional(fields_dict["optional_no_default"])
+    assert attribute_is_optional(fields_dict["optional_with_default_none"])
+    assert attribute_is_optional(fields_dict["optional_with_default_some"])

--- a/fgpyo/util/tests/test_inspect.py
+++ b/fgpyo/util/tests/test_inspect.py
@@ -1,9 +1,10 @@
-from fgpyo.util.inspect import attribute_is_optional
-from fgpyo.util.inspect import attr_from
-from fgpyo.util.inspect import attribute_has_default
+from typing import Optional
 
 import attr
-from typing import Optional
+
+from fgpyo.util.inspect import attr_from
+from fgpyo.util.inspect import attribute_has_default
+from fgpyo.util.inspect import attribute_is_optional
 
 
 @attr.s(auto_attribs=True, frozen=True)

--- a/fgpyo/util/tests/test_inspect.py
+++ b/fgpyo/util/tests/test_inspect.py
@@ -1,5 +1,6 @@
 from fgpyo.util.inspect import attribute_is_optional
 from fgpyo.util.inspect import attr_from
+from fgpyo.util.inspect import attribute_has_default
 
 import attr
 from typing import Optional
@@ -30,6 +31,16 @@ def test_attr_from() -> None:
 def test_attribute_is_optional() -> None:
     fields_dict = attr.fields_dict(Name)
     assert not attribute_is_optional(fields_dict["required"])
+    assert not attribute_is_optional(fields_dict["custom_parser"])
     assert attribute_is_optional(fields_dict["optional_no_default"])
     assert attribute_is_optional(fields_dict["optional_with_default_none"])
     assert attribute_is_optional(fields_dict["optional_with_default_some"])
+
+
+def test_attribute_has_default() -> None:
+    fields_dict = attr.fields_dict(Name)
+    assert not attribute_has_default(fields_dict["required"])
+    assert not attribute_has_default(fields_dict["custom_parser"])
+    assert attribute_has_default(fields_dict["optional_no_default"])
+    assert attribute_has_default(fields_dict["optional_with_default_none"])
+    assert attribute_has_default(fields_dict["optional_with_default_some"])

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -156,9 +156,9 @@ def test_metrics_read_extra_columns(tmpdir: TmpDir) -> None:
         writer.write(f"{person.name}\t{person.age}\tbar\n")
 
     assert list(Person.read(path=path)) == [person]
-    assert list(Person.read(path=path, skip_extra=True)) == [person]
-    with pytest.raises(AssertionError):
-        list(Metric.read(path=path, skip_extra=False))
+    assert list(Person.read(path=path, ignore_extra_fields=True)) == [person]
+    with pytest.raises(ValueError):
+        list(Metric.read(path=path, ignore_extra_fields=False))
 
 
 def test_metric_header() -> None:


### PR DESCRIPTION
This is a breaking change, since previously it would default to an Assertion Error.

I also fixed a few docstring issues.