### PR TITLE
feat: Support stdin/stdout special cases in sam.reader/writer

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -191,10 +191,10 @@ _IOClasses = (io.TextIOBase, io.BufferedIOBase, io.RawIOBase, io.IOBase)
 """The classes that should be treated as file-like classes"""
 
 _STDIN_PATHS: List[str] = ["-", "stdin", "/dev/stdin"]
-"""Paths that should be opened as stdin."""
+"""Paths that should be opened as standard input."""
 
 _STDOUT_PATHS: List[str] = ["-", "stdout", "/dev/stdout"]
-"""Paths that should be opened as stdout."""
+"""Paths that should be opened as standard output."""
 
 
 @enum.unique


### PR DESCRIPTION
Addressing https://github.com/fulcrumgenomics/fgpyo/issues/67

@nh13 @tfenne would you entertain something like this?

Two open questions 

- whether writing to `stdout` should default to SAM or BAM
- I'm not sure how best to test these. In the past when unit testing against `sys.stdin` I've used `pytest.MonkeyPatch` and a `StringIO`, but `pysam` doesn't support reading from `StringIO`