### PR TITLE
Feature/metric with dataclass or attr

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/test_*.py"       # don't compute coverage of tests

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,6 +51,9 @@ Metric files
 
 .. seealso::
 
+   https://docs.python.org/3/library/dataclasses.html
+       Documentation for the dataclasses standard module
+
    https://www.attrs.org/en/stable/examples.html
 
        The attrs website for bringing back the joy to writing classes.

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -96,7 +96,7 @@ class SegmentType(enum.Enum):
         return self.value
 
 
-@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+@attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class SubReadWithoutQuals:
     """Contains the bases that correspond to the given read segment."""
 
@@ -112,7 +112,7 @@ class SubReadWithoutQuals:
         return self.segment.kind
 
 
-@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+@attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class SubReadWithQuals:
     """Contains the bases and qualities that correspond to the given read segment"""
 
@@ -131,7 +131,7 @@ class SubReadWithQuals:
         return self.segment.kind
 
 
-@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+@attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class ReadSegment:
     """Encapsulates all the information about a segment within a read structure. A segment can
     either have a definite length, in which case length must be Some(Int), or an indefinite length
@@ -203,7 +203,7 @@ class ReadSegment:
             return f"{ANY_LENGTH_CHAR}{self.kind.value}"
 
 
-@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+@attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class ReadStructure(Iterable[ReadSegment]):
     """Describes the structure of a give read.  A read contains one or more read segments. A read
     segment describes a contiguous stretch of bases of the same type (ex. template bases) of some

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -386,7 +386,7 @@ class CigarOp(enum.Enum):
         return self == CigarOp.S or self == CigarOp.H
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(frozen=True, slots=True, auto_attribs=True)
 class CigarElement:
     """Represents an element in a Cigar
 
@@ -395,14 +395,13 @@ class CigarElement:
         - operator (CigarOp): the operator of the element
     """
 
-    length: int = attr.ib()
-    operator: CigarOp = attr.ib()
+    length: int
+    operator: CigarOp
 
-    @length.validator
-    def _validate_length(self, attribute: Any, value: int) -> None:
+    def __attrs_post_init__(self) -> None:
         """Validates the length attribute is greater than zero."""
-        if value <= 0:
-            raise ValueError(f"Cigar element must have a length > 0, found {value}")
+        if self.length <= 0:
+            raise ValueError(f"Cigar element must have a length > 0, found {self.length}")
 
     @property
     def length_on_query(self) -> int:
@@ -424,7 +423,7 @@ class CigarParsingException(Exception):
     pass
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(frozen=True, slots=True, auto_attribs=True)
 class Cigar:
     """Class representing a cigar string.
 
@@ -432,7 +431,7 @@ class Cigar:
         - elements (Tuple[CigarElement, ...]): zero or more cigar elements
     """
 
-    elements: Tuple[CigarElement, ...] = attr.ib(default=())
+    elements: Tuple[CigarElement, ...] = ()
 
     @classmethod
     def from_cigartuples(cls, cigartuples: Optional[List[Tuple[int, int]]]) -> "Cigar":
@@ -519,7 +518,7 @@ class Cigar:
         return sum([elem.length_on_target for elem in self.elements])
 
 
-@attr.s(auto_attribs=True, frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class SupplementaryAlignment:
     """Stores a supplementary alignment record produced by BWA and stored in the SA SAM tag.
 
@@ -532,12 +531,12 @@ class SupplementaryAlignment:
         nm: the number of edits
     """
 
-    reference_name: str = attr.ib()
-    start: int = attr.ib()
-    is_forward: bool = attr.ib()
-    cigar: Cigar = attr.ib()
-    mapq: int = attr.ib()
-    nm: int = attr.ib()
+    reference_name: str
+    start: int
+    is_forward: bool
+    cigar: Cigar
+    mapq: int
+    nm: int
 
     def __str__(self) -> str:
         return ",".join(
@@ -639,7 +638,7 @@ def set_pair_info(r1: AlignedSegment, r2: AlignedSegment, proper_pair: bool = Tr
     r2.template_length = -insert_size
 
 
-@attr.s(auto_attribs=True, frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class ReadEditInfo:
     """
     Counts various stats about how a read compares to a reference sequence.
@@ -728,7 +727,7 @@ def calculate_edit_info(
     )
 
 
-@attr.s(auto_attribs=True, frozen=True)
+@attr.s(frozen=True, auto_attribs=True)
 class Template:
     """A container for alignment records corresponding to a single sequenced template
     or insert.

--- a/fgpyo/sam/tests/test_sam.py
+++ b/fgpyo/sam/tests/test_sam.py
@@ -195,6 +195,12 @@ def test_cigar_element_length_on(
     assert element.length_on_target == length_on_target
 
 
+@pytest.mark.parametrize("character", ["M", "I", "D", "S"])
+def test_invalid_cigar_element(character: str) -> None:
+    with pytest.raises(ValueError):
+        CigarElement(-1, operator=CigarOp.from_character(character))
+
+
 @pytest.mark.parametrize(
     "cigartuples,cigarstring",
     [

--- a/fgpyo/util/tests/test_inspect.py
+++ b/fgpyo/util/tests/test_inspect.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -7,10 +8,14 @@ from typing import Tuple
 import attr
 import pytest
 
+from fgpyo.util.inspect import _attribute_has_default
+from fgpyo.util.inspect import _attribute_is_optional
 from fgpyo.util.inspect import attr_from
-from fgpyo.util.inspect import attribute_has_default
-from fgpyo.util.inspect import attribute_is_optional
 from fgpyo.util.inspect import dict_parser
+from fgpyo.util.inspect import get_fields
+from fgpyo.util.inspect import get_fields_dict
+from fgpyo.util.inspect import is_attr_class
+from fgpyo.util.inspect import is_dataclasses_class
 from fgpyo.util.inspect import list_parser
 from fgpyo.util.inspect import set_parser
 from fgpyo.util.inspect import tuple_parser
@@ -20,6 +25,7 @@ from fgpyo.util.inspect import tuple_parser
 class Name:
     required: str
     custom_parser: str
+    converted: int = attr.field(converter=int)
     optional_no_default: Optional[str]
     optional_with_default_none: Optional[str] = None
     optional_with_default_some: Optional[str] = "foo"
@@ -28,11 +34,12 @@ class Name:
 def test_attr_from() -> None:
     name = attr_from(
         cls=Name,
-        kwargs={"required": "required", "custom_parser": "before"},
+        kwargs={"required": "required", "custom_parser": "before", "converted": "42"},
         parsers={str: lambda value: "after" if value == "before" else value},
     )
     assert name.required == "required"
     assert name.custom_parser == "after"
+    assert name.converted == 42
     assert name.optional_no_default is None
     assert name.optional_with_default_none is None
     assert name.optional_with_default_some == "foo"
@@ -40,20 +47,22 @@ def test_attr_from() -> None:
 
 def test_attribute_is_optional() -> None:
     fields_dict = attr.fields_dict(Name)
-    assert not attribute_is_optional(fields_dict["required"])
-    assert not attribute_is_optional(fields_dict["custom_parser"])
-    assert attribute_is_optional(fields_dict["optional_no_default"])
-    assert attribute_is_optional(fields_dict["optional_with_default_none"])
-    assert attribute_is_optional(fields_dict["optional_with_default_some"])
+    assert not _attribute_is_optional(fields_dict["required"])
+    assert not _attribute_is_optional(fields_dict["custom_parser"])
+    assert not _attribute_is_optional(fields_dict["converted"])
+    assert _attribute_is_optional(fields_dict["optional_no_default"])
+    assert _attribute_is_optional(fields_dict["optional_with_default_none"])
+    assert _attribute_is_optional(fields_dict["optional_with_default_some"])
 
 
 def test_attribute_has_default() -> None:
     fields_dict = attr.fields_dict(Name)
-    assert not attribute_has_default(fields_dict["required"])
-    assert not attribute_has_default(fields_dict["custom_parser"])
-    assert attribute_has_default(fields_dict["optional_no_default"])
-    assert attribute_has_default(fields_dict["optional_with_default_none"])
-    assert attribute_has_default(fields_dict["optional_with_default_some"])
+    assert not _attribute_has_default(fields_dict["required"])
+    assert not _attribute_has_default(fields_dict["custom_parser"])
+    assert not _attribute_has_default(fields_dict["converted"])
+    assert _attribute_has_default(fields_dict["optional_no_default"])
+    assert _attribute_has_default(fields_dict["optional_with_default_none"])
+    assert _attribute_has_default(fields_dict["optional_with_default_some"])
 
 
 class Foo:
@@ -62,6 +71,11 @@ class Foo:
 
 @attr.s(auto_attribs=True, frozen=True)
 class Bar:
+    foo: Foo
+
+
+@dataclasses.dataclass(frozen=True)
+class Baz:
     foo: Foo
 
 
@@ -105,3 +119,27 @@ def test_dict_parser_with_duplicate_keys() -> None:
     parser = dict_parser(Foo, Dict[int, str], {})
     with pytest.raises(ValueError):
         parser("{123;a,123;b}")
+
+
+def test_non_data_class_fails() -> None:
+    class NonDataClass:
+        x: int
+
+    with pytest.raises(TypeError):
+        get_fields_dict(NonDataClass)  # type: ignore
+
+    with pytest.raises(TypeError):
+        get_fields(NonDataClass)  # type: ignore
+
+    with pytest.raises(TypeError):
+        attr_from(cls=NonDataClass, kwargs={"x": "1"}, parsers={int: int})
+
+
+def test_is_attrs_is_dataclasses() -> None:
+    assert not is_attr_class(Foo)
+    assert not is_dataclasses_class(Foo)
+
+    assert is_attr_class(Bar)
+    assert not is_dataclasses_class(Bar)
+    assert is_dataclasses_class(Baz)
+    assert not is_attr_class(Baz)

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -1,5 +1,9 @@
+# attr and dataclasses are both nightmares for type-checking, and trying to combine them both in
+# an if-statement is a level of Hell that Dante never conceived of. Turning off mypy for this file:
+# mypy: ignore-errors
 import enum
 import gzip
+import sys
 from pathlib import Path
 from typing import Any
 from typing import Callable
@@ -8,10 +12,22 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import Union
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+import dataclasses
 
 import attr
 import pytest
 
+from fgpyo.util.inspect import is_attr_class
+from fgpyo.util.inspect import is_dataclasses_class
 from fgpyo.util.metric import Metric
 
 
@@ -21,128 +37,230 @@ class EnumTest(enum.Enum):
     EnumVal3 = "val3"
 
 
-@attr.s(auto_attribs=True, frozen=True)
-class DummyMetric(Metric["DummyMetric"]):
-    int_value: int
-    str_value: str
-    bool_val: bool
-    enum_val: EnumTest = attr.ib()
-    optional_str_value: Optional[str] = attr.ib()
-    optional_int_value: Optional[int] = attr.ib()
-    optional_bool_value: Optional[bool] = attr.ib()
-    optional_enum_value: Optional[EnumTest] = attr.ib()
-    dict_value: Dict[int, str] = attr.ib()
-    tuple_value: Tuple[int, str] = attr.ib()
-    list_value: List[str] = attr.ib()
-    complex_value: Dict[
-        int,
-        Dict[
-            Tuple[int, int],
-            Set[str],
-        ],
-    ] = attr.ib()
+T = TypeVar("T", bound=Type)
 
 
-DUMMY_METRICS: List[DummyMetric] = [
-    DummyMetric(
-        int_value=1,
-        str_value="2",
-        bool_val=True,
-        enum_val=EnumTest.EnumVal1,
-        optional_str_value="test4",
-        optional_int_value=-5,
-        optional_bool_value=True,
-        optional_enum_value=EnumTest.EnumVal3,
-        dict_value={
-            1: "test1",
-        },
-        tuple_value=(0, "test1"),
-        list_value=[],
-        complex_value={1: {(5, 1): set({"mapped_test_val1", "setval2"})}},
-    ),
-    DummyMetric(
-        int_value=1,
-        str_value="2",
-        bool_val=False,
-        enum_val=EnumTest.EnumVal2,
-        optional_str_value="test",
-        optional_int_value=1,
-        optional_bool_value=False,
-        optional_enum_value=EnumTest.EnumVal1,
-        dict_value={2: "test2", 7: "test4"},
-        tuple_value=(1, "test2"),
-        list_value=["1"],
-        complex_value={2: {(-5, 1): set({"mapped_test_val2", "setval2"})}},
-    ),
-    DummyMetric(
-        int_value=1,
-        str_value="2",
-        bool_val=False,
-        enum_val=EnumTest.EnumVal3,
-        optional_str_value=None,
-        optional_int_value=None,
-        optional_bool_value=None,
-        optional_enum_value=None,
-        dict_value={},
-        tuple_value=(2, "test3"),
-        list_value=["1", "2", "3"],
-        complex_value={3: {(8, 1): set({"mapped_test_val3", "setval2"})}},
-    ),
-]
+def make_dataclass(use_attr: bool = False) -> Callable[[T], T]:
+    """Decorator to make a attr- or dataclasses-style dataclass"""
+    sys.stderr.write(f"use_attr = {use_attr}\n")
+    if use_attr:
+
+        def make_attr(cls: T) -> T:
+            return attr.s(auto_attribs=True, frozen=True)(cls)
+
+        return make_attr
+    else:
+
+        def make_dataclasses(cls: T) -> T:
+            return dataclasses.dataclass(frozen=True)(cls)
+
+        return make_dataclasses
 
 
-@attr.s(auto_attribs=True, frozen=True)
-class Person(Metric["Person"]):
-    name: Optional[str]
-    age: Optional[int]
+class DataBuilder:
+    """
+    Holds classes and data for testing, either using attr- or dataclasses-style dataclass
+    We need to run each test both with attr and dataclasses classes, so use this class to construct
+    the test metrics appropriately, governed by the use_attr flag. After construction, the
+    DataBuilder object will have all the required Metrics:
+
+    Attributes:
+        use_attr: If True use attr classes for Metrics, if False use dataclasses
+        DummyMetric: Metric with many different field types
+        Person: Metric with optional name and age string fields
+        Name: Metric with first and last name string fields and a parse method
+        NamedPerson: Metric with name (Name Metric) field and age (int) fields, and parsers.
+        PersonMaybeAge = Person with required name string field and optional age int field
+        PersonDefault = Person with required name string field and age int field with default value
+        ListPerson = Person with list[str] name and list[int] age fields
+        DUMMY_METRICS: a list of 3 different DummyMetrics
+    """
+
+    def __init__(self, use_attr: bool) -> None:
+        self.use_attr = use_attr
+
+        @make_dataclass(use_attr=use_attr)
+        class DummyMetric(Metric["DummyMetric"]):
+            int_value: int
+            str_value: str
+            bool_val: bool
+            enum_val: EnumTest
+            optional_str_value: Optional[str]
+            optional_int_value: Optional[int]
+            optional_bool_value: Optional[bool]
+            optional_enum_value: Optional[EnumTest]
+            dict_value: Dict[int, str]
+            tuple_value: Tuple[int, str]
+            list_value: List[str]
+            complex_value: Dict[
+                int,
+                Dict[
+                    Tuple[int, int],
+                    Set[str],
+                ],
+            ]
+
+        @make_dataclass(use_attr=use_attr)
+        class Person(Metric["Person"]):
+            name: Optional[str]
+            age: Optional[int]
+
+        @make_dataclass(use_attr=use_attr)
+        class Name:
+            first: str
+            last: str
+
+            @classmethod
+            def parse(cls, value: str) -> "Name":
+                fields = value.split(" ")
+                return Name(first=fields[0], last=fields[1])
+
+        @make_dataclass(use_attr=use_attr)
+        class NamedPerson(Metric["NamedPerson"]):
+            name: Name
+            age: int
+
+            @classmethod
+            def _parsers(cls) -> Dict[type, Callable[[str], Any]]:
+                return {Name: lambda value: Name.parse(value=value)}
+
+            @classmethod
+            def format_value(cls, value: Any) -> str:
+                if isinstance(value, (Name)):
+                    return f"{value.first} {value.last}"
+                else:
+                    return super().format_value(value=value)
+
+        @make_dataclass(use_attr=use_attr)
+        class PersonMaybeAge(Metric["PersonMaybeAge"]):
+            name: str
+            age: Optional[int]
+
+        @make_dataclass(use_attr=use_attr)
+        class PersonDefault(Metric["PersonDefault"]):
+            name: str
+            age: int = 0
+
+        @make_dataclass(use_attr=use_attr)
+        class ListPerson(Metric["ListPerson"]):
+            name: List[Optional[str]]
+            age: List[Optional[int]]
+
+        self.DummyMetric = DummyMetric
+        self.Person = Person
+        self.Name = Name
+        self.NamedPerson = NamedPerson
+        self.PersonMaybeAge = PersonMaybeAge
+        self.PersonDefault = PersonDefault
+        self.ListPerson = ListPerson
+
+        self.DUMMY_METRICS: List[DummyMetric] = [
+            DummyMetric(
+                int_value=1,
+                str_value="2",
+                bool_val=True,
+                enum_val=EnumTest.EnumVal1,
+                optional_str_value="test4",
+                optional_int_value=-5,
+                optional_bool_value=True,
+                optional_enum_value=EnumTest.EnumVal3,
+                dict_value={
+                    1: "test1",
+                },
+                tuple_value=(0, "test1"),
+                list_value=[],
+                complex_value={1: {(5, 1): {"mapped_test_val1", "setval2"}}},
+            ),
+            DummyMetric(
+                int_value=1,
+                str_value="2",
+                bool_val=False,
+                enum_val=EnumTest.EnumVal2,
+                optional_str_value="test",
+                optional_int_value=1,
+                optional_bool_value=False,
+                optional_enum_value=EnumTest.EnumVal1,
+                dict_value={2: "test2", 7: "test4"},
+                tuple_value=(1, "test2"),
+                list_value=["1"],
+                complex_value={2: {(-5, 1): {"mapped_test_val2", "setval2"}}},
+            ),
+            DummyMetric(
+                int_value=1,
+                str_value="2",
+                bool_val=False,
+                enum_val=EnumTest.EnumVal3,
+                optional_str_value=None,
+                optional_int_value=None,
+                optional_bool_value=None,
+                optional_enum_value=None,
+                dict_value={},
+                tuple_value=(2, "test3"),
+                list_value=["1", "2", "3"],
+                complex_value={3: {(8, 1): {"mapped_test_val3", "setval2"}}},
+            ),
+        ]
 
 
-@attr.s(auto_attribs=True, frozen=True)
-class Name:
-    first: str
-    last: str
+# construct the attr and dataclasses DataBuilder objects
+attr_data_and_classes = DataBuilder(use_attr=True)
+dataclasses_data_and_classes = DataBuilder(use_attr=False)
 
-    @classmethod
-    def parse(cls, value: str) -> "Name":
-        fields = value.split(" ")
-        return Name(first=fields[0], last=fields[1])
+# get helper type and helper num_metrics that will be used frequently in tests
+AnyDummyMetric = Union[attr_data_and_classes.DummyMetric, dataclasses_data_and_classes.DummyMetric]
+num_metrics = len(attr_data_and_classes.DUMMY_METRICS)
 
 
-@attr.s(auto_attribs=True, frozen=True)
-class NamedPerson(Metric["NamedPerson"]):
-    name: Name
-    age: int
-
-    @classmethod
-    def _parsers(cls) -> Dict[type, Callable[[str], Any]]:
-        return {Name: lambda value: Name.parse(value=value)}
-
-    @classmethod
-    def format_value(cls, value: Any) -> str:
-        if isinstance(value, (Name)):
-            return f"{value.first} {value.last}"
-        else:
-            return super().format_value(value=value)
-
-
-@attr.s(auto_attribs=True, frozen=True)
-class PersonMaybeAge(Metric["PersonMaybeAge"]):
-    name: str
-    age: Optional[int]
-
-
-@attr.s(auto_attribs=True, frozen=True)
-class PersonDefault(Metric["PersonDefault"]):
-    name: str
-    age: int = 0
+@pytest.mark.parametrize("use_attr", [False, True])
+def test_is_correct_dataclass_type(use_attr: bool) -> None:
+    """
+    Test that the DataBuilder class works as expected, as do the is_attr_class and
+    is_dataclasses_class methods
+    """
+    data_and_classes = DataBuilder(use_attr=use_attr)
+    assert use_attr == data_and_classes.use_attr
+    assert is_attr_class(data_and_classes.DummyMetric) is use_attr
+    assert is_dataclasses_class(data_and_classes.DummyMetric) is not use_attr
+    assert is_attr_class(data_and_classes.Person) is use_attr
+    assert is_dataclasses_class(data_and_classes.Person) is not use_attr
+    assert is_attr_class(data_and_classes.Name) is use_attr
+    assert is_dataclasses_class(data_and_classes.Name) is not use_attr
+    assert is_attr_class(data_and_classes.NamedPerson) is use_attr
+    assert is_dataclasses_class(data_and_classes.NamedPerson) is not use_attr
+    assert is_attr_class(data_and_classes.PersonMaybeAge) is use_attr
+    assert is_dataclasses_class(data_and_classes.PersonMaybeAge) is not use_attr
+    assert is_attr_class(data_and_classes.PersonDefault) is use_attr
+    assert is_dataclasses_class(data_and_classes.PersonDefault) is not use_attr
+    assert len(data_and_classes.DUMMY_METRICS) == num_metrics
 
 
-@pytest.mark.parametrize("metric", DUMMY_METRICS)
+def pytest_generate_tests(metafunc: Any) -> None:
+    if "DummyMetric" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "DummyMetric",
+            [attr_data_and_classes.DummyMetric, dataclasses_data_and_classes.DummyMetric],
+        )
+    if "DUMMY_METRICS" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "DUMMY_METRICS",
+            [attr_data_and_classes.DUMMY_METRICS, dataclasses_data_and_classes.DUMMY_METRICS],
+        )
+
+
+@pytest.fixture(scope="function")
+def metric(request, data_and_classes: DataBuilder) -> AnyDummyMetric:
+    yield data_and_classes.DUMMY_METRICS[request.param]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+@pytest.mark.parametrize("metric", range(num_metrics), indirect=True)
 def test_metric_roundtrip(
     tmp_path: Path,
-    metric: DummyMetric,
+    data_and_classes: DataBuilder,
+    metric: AnyDummyMetric,
 ) -> None:
     path: Path = tmp_path / "metrics.txt"
+    DummyMetric: TypeAlias = data_and_classes.DummyMetric
 
     DummyMetric.write(path, metric)
     metrics: List[DummyMetric] = list(DummyMetric.read(path=path))
@@ -151,31 +269,37 @@ def test_metric_roundtrip(
     assert metrics[0] == metric
 
 
-def test_metrics_roundtrip(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metrics_roundtrip(tmp_path: Path, data_and_classes: DataBuilder) -> None:
     path: Path = tmp_path / "metrics.txt"
+    DummyMetric: TypeAlias = data_and_classes.DummyMetric
 
-    DummyMetric.write(path, *DUMMY_METRICS)
+    DummyMetric.write(path, *data_and_classes.DUMMY_METRICS)
     metrics: List[DummyMetric] = list(DummyMetric.read(path=path))
 
-    assert len(metrics) == len(DUMMY_METRICS)
-    assert metrics == DUMMY_METRICS
+    assert len(metrics) == len(data_and_classes.DUMMY_METRICS)
+    assert metrics == data_and_classes.DUMMY_METRICS
 
 
-def test_metrics_roundtrip_gzip(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metrics_roundtrip_gzip(tmp_path: Path, data_and_classes: DataBuilder) -> None:
     path: Path = Path(tmp_path) / "metrics.txt.gz"
+    DummyMetric: Type[Metric] = data_and_classes.DummyMetric
 
-    DummyMetric.write(path, *DUMMY_METRICS)
+    DummyMetric.write(path, *data_and_classes.DUMMY_METRICS)
 
     with gzip.open(path, "r") as handle:
         handle.read(1)  # Will raise an exception if not a GZIP file.
 
     metrics: List[DummyMetric] = list(DummyMetric.read(path=path))
 
-    assert len(metrics) == len(DUMMY_METRICS)
-    assert metrics == DUMMY_METRICS
+    assert len(metrics) == len(data_and_classes.DUMMY_METRICS)
+    assert metrics == data_and_classes.DUMMY_METRICS
 
 
-def test_metrics_read_extra_columns(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metrics_read_extra_columns(tmp_path: Path, data_and_classes: DataBuilder) -> None:
+    Person: TypeAlias = data_and_classes.Person
     person = Person(name="Max", age=42)
     path = tmp_path / "metrics.txt"
     with path.open("w") as writer:
@@ -190,7 +314,11 @@ def test_metrics_read_extra_columns(tmp_path: Path) -> None:
         list(Person.read(path=path, ignore_extra_fields=False))
 
 
-def test_metrics_read_missing_optional_columns(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metrics_read_missing_optional_columns(
+    tmp_path: Path, data_and_classes: DataBuilder
+) -> None:
+    PersonMaybeAge: TypeAlias = data_and_classes.PersonMaybeAge
     person = PersonMaybeAge(name="Max", age=None)
     path = tmp_path / "metrics.txt"
 
@@ -206,7 +334,11 @@ def test_metrics_read_missing_optional_columns(tmp_path: Path) -> None:
         list(PersonMaybeAge.read(path=path))
 
 
-def test_metric_read_missing_column_with_default(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_read_missing_column_with_default(
+    tmp_path: Path, data_and_classes: DataBuilder
+) -> None:
+    PersonDefault: TypeAlias = data_and_classes.PersonDefault
     person = PersonDefault(name="Max")
     path = tmp_path / "metrics.txt"
 
@@ -227,8 +359,9 @@ def test_metric_read_missing_column_with_default(tmp_path: Path) -> None:
         list(PersonDefault.read(path=path))
 
 
-def test_metric_header() -> None:
-    assert DummyMetric.header() == [
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_header(data_and_classes: DataBuilder) -> None:
+    assert data_and_classes.DummyMetric.header() == [
         "int_value",
         "str_value",
         "bool_val",
@@ -244,60 +377,72 @@ def test_metric_header() -> None:
     ]
 
 
-def test_metric_values() -> None:
-    assert list(Person(name="name", age=42).values()) == ["name", 42]
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_values(data_and_classes: DataBuilder) -> None:
+    assert list(data_and_classes.Person(name="name", age=42).values()) == ["name", 42]
 
 
-def test_metric_parse() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_parse(data_and_classes: DataBuilder) -> None:
+    Person: TypeAlias = data_and_classes.Person
     assert Person.parse(fields=["name", "42"]) == Person(name="name", age=42)
 
 
-def test_metric_formatted_values() -> None:
-    assert Person(name="name", age=42).formatted_values() == (["name", "42"])
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_formatted_values(data_and_classes: DataBuilder) -> None:
+    assert data_and_classes.Person(name="name", age=42).formatted_values() == (["name", "42"])
 
 
-def test_metric_custom_parser() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_custom_parser(data_and_classes: DataBuilder) -> None:
+    NamedPerson: TypeAlias = data_and_classes.NamedPerson
     assert NamedPerson.parse(fields=["john doe", "42"]) == (
-        NamedPerson(name=Name(first="john", last="doe"), age=42)
+        NamedPerson(name=data_and_classes.Name(first="john", last="doe"), age=42)
     )
 
 
-def test_metric_custom_formatter() -> None:
-    person = NamedPerson(name=Name(first="john", last="doe"), age=42)
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_custom_formatter(data_and_classes: DataBuilder) -> None:
+    person = data_and_classes.NamedPerson(
+        name=data_and_classes.Name(first="john", last="doe"), age=42
+    )
     assert list(person.formatted_values()) == ["john doe", "42"]
 
 
-def test_metric_parse_with_none() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_parse_with_none(data_and_classes: DataBuilder) -> None:
+    Person: TypeAlias = data_and_classes.Person
     assert Person.parse(fields=["", "40"]) == Person(name=None, age=40)
     assert Person.parse(fields=["Sally", ""]) == Person(name="Sally", age=None)
     assert Person.parse(fields=["", ""]) == Person(name=None, age=None)
 
 
-def test_metric_formatted_values_with_empty_string() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_formatted_values_with_empty_string(data_and_classes: DataBuilder) -> None:
+    Person: TypeAlias = data_and_classes.Person
     assert Person(name=None, age=42).formatted_values() == (["", "42"])
     assert Person(name="Sally", age=None).formatted_values() == (["Sally", ""])
     assert Person(name=None, age=None).formatted_values() == (["", ""])
 
 
-@attr.s(auto_attribs=True, frozen=True)
-class ListPerson(Metric["ListPerson"]):
-    name: List[Optional[str]]
-    age: List[Optional[int]]
-
-
-def test_metric_list_format() -> None:
-    assert ListPerson(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_list_format(data_and_classes: DataBuilder) -> None:
+    assert data_and_classes.ListPerson(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
         ["Max,Sally", "43,55"]
     )
 
 
-def test_metric_list_parse() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_list_parse(data_and_classes: DataBuilder) -> None:
+    ListPerson: TypeAlias = data_and_classes.ListPerson
     assert ListPerson.parse(fields=["Max,Sally", "43, 55"]) == ListPerson(
         name=["Max", "Sally"], age=[43, 55]
     )
 
 
-def test_metric_list_format_with_empty_string() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_list_format_with_empty_string(data_and_classes: DataBuilder) -> None:
+    ListPerson: TypeAlias = data_and_classes.ListPerson
     assert ListPerson(name=[None, "Sally"], age=[43, 55]).formatted_values() == (
         [",Sally", "43,55"]
     )
@@ -309,7 +454,9 @@ def test_metric_list_format_with_empty_string() -> None:
     )
 
 
-def test_metric_list_parse_with_none() -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_list_parse_with_none(data_and_classes: DataBuilder) -> None:
+    ListPerson: TypeAlias = data_and_classes.ListPerson
     assert ListPerson.parse(fields=[",Sally", "40, 30"]) == ListPerson(
         name=[None, "Sally"], age=[40, 30]
     )
@@ -321,13 +468,16 @@ def test_metric_list_parse_with_none() -> None:
     )
 
 
-def test_metrics_fast_concat(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metrics_fast_concat(tmp_path: Path, data_and_classes: DataBuilder) -> None:
     path_input = [
         tmp_path / "metrics_1.txt",
         tmp_path / "metrics_2.txt",
         tmp_path / "metrics_3.txt",
     ]
     path_output: Path = tmp_path / "metrics_concat.txt"
+    DummyMetric: TypeAlias = data_and_classes.DummyMetric
+    DUMMY_METRICS: list[DummyMetric] = data_and_classes.DUMMY_METRICS
 
     DummyMetric.write(path_input[0], DUMMY_METRICS[0])
     DummyMetric.write(path_input[1], DUMMY_METRICS[1])

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -94,6 +94,7 @@ def _make_union_parser_worker(
             return None
         except (ValueError, InspectException):
             pass
+
     for p in parsers:
         try:
             return p(value)


### PR DESCRIPTION
Solving the issue was not particularly easy, but the real battle is with `mypy`. Reviewers should be aware that both [dataclasses](https://mypy.readthedocs.io/en/stable/additional_features.html#caveats-known-issues) and [attr](https://mypy.readthedocs.io/en/stable/additional_features.html#the-attrs-package) modules have weird enough issues with type hints that they basically lie; and `mypy` has special code to figure out what's going on. Thus I had to make use of `# type: ignore` in multiple locations in actual code, and had to completely exclude `test_metric.py` from even being checked.

Also in an offline conversation with @tfenne I dropped changing `attr` from a package requirement to a dev/test requirement, because several attr-decorated classes in the main fgpyo codebase use the `slots` and `kw_only` keywords, which are only supported in `dataclasses` for python versions >= 3.10.