### PR TITLE
chore: isort

### DIFF
--- a/fgpyo/fastx/__init__.py
+++ b/fgpyo/fastx/__init__.py
@@ -27,15 +27,16 @@ the state of all previously iterated records, set the parameter ``persist`` to :
 from contextlib import AbstractContextManager
 from pathlib import Path
 from types import TracebackType
-from typing import cast
 from typing import Iterator
 from typing import Optional
-from typing import Union
 from typing import Set
 from typing import Tuple
 from typing import Type
+from typing import Union
+from typing import cast
 
-from pysam import FastxFile, FastxRecord
+from pysam import FastxFile
+from pysam import FastxRecord
 
 
 class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):

--- a/fgpyo/fastx/tests/test_fastx_zipped.py
+++ b/fgpyo/fastx/tests/test_fastx_zipped.py
@@ -1,5 +1,4 @@
 import gzip
-
 from pathlib import Path
 
 import pytest

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -70,7 +70,6 @@ from typing import Tuple
 
 import attr
 
-
 ANY_LENGTH_CHAR: str = "+"
 """A character that can be put in place of a number in a read structure to mean "0 or more bases".
 """


### PR DESCRIPTION
isort insisted on fixing these when I ran `ci/check.sh`  - afaict I'm using the version specified in the lock file, 5.10.1