### PR TITLE
feat: Support reading Picard-style metrics files with comments above the header

### DIFF
--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -214,7 +214,7 @@ class Metric(ABC, Generic[MetricType]):
         cls,
         path: Path,
         ignore_extra_fields: bool = True,
-        comment_prefix: str = "#",
+        comment_prefix: Optional[str] = None,
     ) -> Iterator["Metric[MetricType]"]:
         """Reads in zero or more metrics from the given path.
 
@@ -397,7 +397,7 @@ class Metric(ABC, Generic[MetricType]):
     def _read_header(
         reader: TextIOWrapper,
         delimiter: str = "\t",
-        comment_prefix: str = "#",
+        comment_prefix: Optional[str] = None,
     ) -> MetricFileHeader:
         """
         Read the header from an open file.
@@ -422,12 +422,17 @@ class Metric(ABC, Generic[MetricType]):
         preamble: List[str] = []
 
         for line in reader:
-            if line.strip().startswith(comment_prefix) or line.strip() == "":
-                # Skip any commented or empty lines before the header
-                preamble.append(line.strip())
+            line = line.strip()
+
+            if line == "":
+                # Skip any empty lines before the header
+                preamble.append(line)
+            elif comment_prefix is not None and line.startswith(comment_prefix):
+                # Skip any commented lines before the header
+                preamble.append(line)
             else:
                 # The first line with any other content is assumed to be the header
-                fieldnames = line.strip().split(delimiter)
+                fieldnames = line.split(delimiter)
                 break
         else:
             # If the file was empty, kick back an empty header

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -237,8 +237,8 @@ class Metric(ABC, Generic[MetricType]):
             try:
                 header = cls._read_header(reader, comment_prefix=comment_prefix)
                 fieldnames: List[str] = header.fieldnames
-            except ValueError:
-                raise ValueError(f"No header found in file: {path}")
+            except ValueError as e:
+                raise ValueError(f"No header found in file: {path}") from e
 
             # check the header
             class_fields = set(cls.header())

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -234,11 +234,11 @@ class Metric(ABC, Generic[MetricType]):
         """
         parsers = cls._parsers()
         with io.to_reader(path) as reader:
-            try:
-                header = cls._read_header(reader, comment_prefix=comment_prefix)
-                fieldnames: List[str] = header.fieldnames
-            except ValueError as e:
-                raise ValueError(f"No header found in file: {path}") from e
+            header = cls._read_header(reader, comment_prefix=comment_prefix)
+            fieldnames: List[str] = header.fieldnames
+
+            if not fieldnames:
+                raise ValueError(f"No header found in file: {path}")
 
             # check the header
             class_fields = set(cls.header())

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -898,6 +898,7 @@ def test_assert_file_header_matches_metric_raises(
         _assert_file_header_matches_metric(metric_path, data_and_classes.Person, delimiter="\t")
 
 
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 @pytest.mark.parametrize(
     "lines",
     [
@@ -907,7 +908,11 @@ def test_assert_file_header_matches_metric_raises(
         ["", "# comment"],
     ],
 )
-def test_read_validates_no_header(tmp_path: Path, lines: List[str]) -> None:
+def test_read_validates_no_header(
+    tmp_path: Path,
+    data_and_classes: DataBuilder,
+    lines: List[str],
+) -> None:
     """
     Test our handling of a file with no header.
 
@@ -921,5 +926,4 @@ def test_read_validates_no_header(tmp_path: Path, lines: List[str]) -> None:
         metrics_file.writelines(lines)
 
     with pytest.raises(ValueError, match="No header found"):
-        [m for m in dataclasses_data_and_classes.DummyMetric.read(metrics_path)]
-
+        [m for m in data_and_classes.DummyMetric.read(metrics_path)]

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -926,4 +926,4 @@ def test_read_validates_no_header(
         metrics_file.writelines(lines)
 
     with pytest.raises(ValueError, match="No header found"):
-        [m for m in data_and_classes.DummyMetric.read(metrics_path)]
+        [m for m in data_and_classes.DummyMetric.read(metrics_path, comment_prefix="#")]

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -896,3 +896,30 @@ def test_assert_file_header_matches_metric_raises(
 
     with pytest.raises(ValueError, match="The provided file does not have the same field names"):
         _assert_file_header_matches_metric(metric_path, data_and_classes.Person, delimiter="\t")
+
+
+@pytest.mark.parametrize(
+    "lines",
+    [
+        [],
+        [""],
+        ["# comment"],
+        ["", "# comment"],
+    ],
+)
+def test_read_validates_no_header(tmp_path: Path, lines: List[str]) -> None:
+    """
+    Test our handling of a file with no header.
+
+    1. The helper `Metric._read_header` returns None
+    2. `Metric.read` raises `ValueError`
+    """
+
+    metrics_path = tmp_path / "bad_metrics"
+
+    with metrics_path.open("w") as metrics_file:
+        metrics_file.writelines(lines)
+
+    with pytest.raises(ValueError, match="No header found"):
+        [m for m in dataclasses_data_and_classes.DummyMetric.read(metrics_path)]
+


### PR DESCRIPTION
It would be helpful if `Metric.read` could parse metrics files with comments above the header, such as those produced by Picard. I've updated `Metric.read` to use the `read_header()` method introduced in #124 , and also simplified the typing on `io.to_reader()` and `io.to_writer()` (per Clint's suggestion)

---

**note** I want to keep this separate from the `MetricWriter` feature branch, but it's dependent on the `Metric._read_header` method introduced in that branch.

I am waiting to merge until #123 is merged.