### PR TITLE
feat: Add end property on SupplementaryAlignment

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -551,6 +551,11 @@ class SupplementaryAlignment:
             )
         )
 
+    @property
+    def end(self) -> int:
+        """The 0-based exclusive end position of the alignment."""
+        return self.start + self.cigar.length_on_target()
+
     @staticmethod
     def parse(string: str) -> "SupplementaryAlignment":
         """Returns a supplementary alignment parsed from the given string.  The various fields

--- a/fgpyo/sam/tests/test_supplementary_alignments.py
+++ b/fgpyo/sam/tests/test_supplementary_alignments.py
@@ -69,3 +69,12 @@ def test_from_read() -> None:
 
     read = builder.add_single(attrs={"SA": f"{s1};{s2};"})
     assert SupplementaryAlignment.from_read(read) == [sa1, sa2]
+
+
+def test_end() -> None:
+    """Test that we can get the end of a SupplementaryAlignment."""
+
+    s1 = SupplementaryAlignment.parse("chr1,123,+,50S100M,60,0")
+
+    # NB: the SA tag is one-based, but SupplementaryAlignment is zero-based
+    assert s1.end == 222


### PR DESCRIPTION
I have a context where it'd be helpful if the `end` were readily accessible. 