### PR TITLE
fix: DataclassInstance and AttrInstance protocols

### DIFF
--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -73,8 +73,9 @@ if TYPE_CHECKING:  # pragma: no cover
 else:
 
     # https://github.com/python/typeshed/blob/727f3c4320d2af3af2f16695e24dd78e79b7c070/stdlib/_typeshed/__init__.pyi#L348
+    # TODO: update the hint to `Field[Any]` when we drop support for 3.8
     class DataclassInstance(Protocol):
-        __dataclasses_fields__: ClassVar[Dict[str, dataclasses.Field[Any]]]
+        __dataclasses_fields__: ClassVar[Dict[str, dataclasses.Field]]
 
 
 if TYPE_CHECKING and _use_attr:  # pragma: no cover

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -68,10 +68,10 @@ except ImportError:  # pragma: no cover
     MISSING = frozenset({DATACLASSES_MISSING})
 
 if TYPE_CHECKING:  # pragma: no cover
-    from _typeshed import DataclassInstance as DataclassesProtocol
+    from _typeshed import DataclassInstance
 else:
 
-    class DataclassesProtocol(Protocol):
+    class DataclassInstance(Protocol):
         __dataclasses_fields__: Dict[str, dataclasses.Field]
 
 
@@ -90,7 +90,7 @@ def is_attr_class(cls: type) -> bool:  # type: ignore[arg-type]
 
 _MISSING_OR_NONE: FrozenSet[Any] = frozenset({*MISSING, None})
 """Set of values that are considered missing or None for dataclasses or attr classes"""
-_DataclassesOrAttrClass: TypeAlias = Union[DataclassesProtocol, AttrsInstance]
+_DataclassesOrAttrClass: TypeAlias = Union[DataclassInstance, AttrsInstance]
 """
 TypeAlias for dataclasses or attr classes. Mostly nonsense because they are not true types, they
 are traits, but there is no python trait-tester.
@@ -103,7 +103,7 @@ corresponding _DataclassesOrAttrClass
 
 
 def _get_dataclasses_fields_dict(
-    class_or_instance: Union[DataclassesProtocol, Type[DataclassesProtocol]],
+    class_or_instance: Union[DataclassInstance, Type[DataclassInstance]],
 ) -> Dict[str, dataclasses.Field]:
     """Get a dict from field name to Field for a dataclass class or instance."""
     return {field.name: field for field in get_dataclasses_fields(class_or_instance)}

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -2,6 +2,7 @@ import sys
 import types as python_types
 import typing
 from typing import Any
+from typing import ClassVar
 from typing import Dict
 from typing import FrozenSet
 from typing import Iterable
@@ -71,16 +72,18 @@ if TYPE_CHECKING:  # pragma: no cover
     from _typeshed import DataclassInstance
 else:
 
+    # https://github.com/python/typeshed/blob/727f3c4320d2af3af2f16695e24dd78e79b7c070/stdlib/_typeshed/__init__.pyi#L348
     class DataclassInstance(Protocol):
-        __dataclasses_fields__: Dict[str, dataclasses.Field]
+        __dataclasses_fields__: ClassVar[Dict[str, dataclasses.Field[Any]]]
 
 
 if TYPE_CHECKING and _use_attr:  # pragma: no cover
     from attr import AttrsInstance
 else:
 
+    # https://github.com/python-attrs/attrs/blob/f7f317ae4c3790f23ae027db626593d50e8a4e88/src/attr/_typing_compat.pyi#L9
     class AttrsInstance(Protocol):  # type: ignore[no-redef]
-        __attrs_attrs__: Dict[str, Any]
+        __attrs_attrs__: ClassVar[Any]
 
 
 def is_attr_class(cls: type) -> bool:  # type: ignore[arg-type]

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -71,7 +71,6 @@ except ImportError:  # pragma: no cover
 if TYPE_CHECKING:  # pragma: no cover
     from _typeshed import DataclassInstance
 else:
-
     # https://github.com/python/typeshed/blob/727f3c4320d2af3af2f16695e24dd78e79b7c070/stdlib/_typeshed/__init__.pyi#L348
     # TODO: update the hint to `Field[Any]` when we drop support for 3.8
     class DataclassInstance(Protocol):
@@ -81,7 +80,6 @@ else:
 if TYPE_CHECKING and _use_attr:  # pragma: no cover
     from attr import AttrsInstance
 else:
-
     # https://github.com/python-attrs/attrs/blob/f7f317ae4c3790f23ae027db626593d50e8a4e88/src/attr/_typing_compat.pyi#L9
     class AttrsInstance(Protocol):  # type: ignore[no-redef]
         __attrs_attrs__: ClassVar[Any]


### PR DESCRIPTION
This PR includes two minor QoL fixes

- I found the aliased import of `DataclassInstance` to `DataclassesProtocol` unnecessary, especially since it conflicted with the naming convention of `AttrInstance`
- I updated the `*Instance` definitions to reflect the canonical definitions for each. (In particular, the implementation for `AttrInstance` was bugged since `__attrs_attrs__` can be a tuple of attributes, not a dict)