### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners: Nils and Tim
+*  @nh13 @tfenne


### PR DESCRIPTION
Closes #111 

@nh13 @tfenne I added you both as default codeowners. Let me know if you think there should be additional default owners, or if there should be any module-specific owners.