### PR TITLE
fix: r/w assertions

### DIFF
--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -148,7 +148,7 @@ def assert_path_is_writable(path: Path, parent_must_exist: bool = True) -> None:
     # Else if file doesn't exist and parent_must_exist is False, test parent until
     # you find the first extant path, and check that it is a directory and is writable.
     else:
-        for parent in path.parents:
+        for parent in path.absolute().parents:
             if parent.exists():
                 assert os.access(parent, os.W_OK), f"Parent directory is not writable: {parent}"
                 break

--- a/fgpyo/io/tests/test_io.py
+++ b/fgpyo/io/tests/test_io.py
@@ -2,13 +2,13 @@
 
 import io
 import os
+import stat
 from pathlib import Path
-from tempfile import NamedTemporaryFile as NamedTemp
+from tempfile import NamedTemporaryFile
 from typing import Any
 from typing import List
 
 import pytest
-from pytest import raises
 
 import fgpyo.io as fio
 from fgpyo.io import assert_path_is_writable
@@ -18,22 +18,24 @@ from fgpyo.io import assert_path_is_writeable
 def test_assert_path_is_readable_missing_file_error() -> None:
     """Error when file does not exist"""
     path = Path("error.txt")
-    with raises(AssertionError):
+
+    with pytest.raises(AssertionError):
         fio.assert_path_is_readable(path=path)
 
 
 def test_assert_path_is_readable_mode_error() -> None:
     """Error when permissions are write only by owner"""
-    with NamedTemp(suffix=".txt", mode="r", delete=True) as write_file:
+    with NamedTemporaryFile(suffix=".txt", mode="r", delete=True) as write_file:
         path = Path(write_file.name)
-        os.chmod(path, 0o00200)  # Write only permissions
-        with raises(AssertionError):
+        os.chmod(path, stat.S_IWUSR)  # Write only permissions
+
+        with pytest.raises(AssertionError):
             fio.assert_path_is_readable(path=path)
 
 
 def test_assert_path_is_readable_pass() -> None:
     """Returns none when no assertions are violated"""
-    with NamedTemp(suffix=".txt", mode="w", delete=True) as write_file:
+    with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as write_file:
         path = Path(write_file.name)
         fio.assert_path_is_readable(path=path)
 
@@ -41,46 +43,43 @@ def test_assert_path_is_readable_pass() -> None:
 def test_assert_directory_exists_error() -> None:
     """Ensure OSError when directory does not exist"""
     path = Path("/non/existent/dir/")
-    with raises(AssertionError):
+    with pytest.raises(AssertionError):
         fio.assert_directory_exists(path)
 
 
 def test_assert_directory_exists_pass() -> None:
     """Asserts fio._assert_directory_exists() returns True when directory exists"""
-    with NamedTemp(suffix=".txt", mode="w", delete=True) as write_file:
+    with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as write_file:
         path = Path(write_file.name)
         fio.assert_directory_exists(path=path.parent.absolute())
 
 
 def test_assert_path_is_writable_mode_error() -> None:
     """Error when permissions are read only by owner"""
-    with NamedTemp(suffix=".txt", mode="w", delete=True) as read_file:
+    with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as read_file:
         path = Path(read_file.name)
-        os.chmod(path, 0o00400)  # Read only permissions
-        with raises(AssertionError, match=f"File exists but is not writable: {path}"):
+        os.chmod(path, stat.S_IRUSR)  # Read only permissions
+        with pytest.raises(AssertionError, match=f"File exists but is not writable: {path}"):
             assert_path_is_writable(path=path)
 
 
 def test_assert_path_is_writable_parent_not_writable() -> None:
     """Error when parent_must_exist is false and no writable parent directory exists"""
     path = Path("/no/parent/exists/")
-    with raises(AssertionError, match=f"File does not have a writable parent directory: {path}"):
+    with pytest.raises(AssertionError, match="Parent directory is not writable: /"):
         assert_path_is_writable(path=path, parent_must_exist=False)
 
 
 def test_assert_path_is_writable_file_does_not_exist() -> None:
     """Error when file does not exist"""
     path = Path("example/non_existent_file.txt")
-    with raises(
-        AssertionError,
-        match="Path does not exist and parent isn't extant/writable: example/non_existent_file.txt",
-    ):
+    with pytest.raises(AssertionError, match="Parent directory does not exist:"):
         assert_path_is_writable(path=path)
 
 
 def test_assert_path_is_writable_pass() -> None:
     """Should return the correct writable path"""
-    with NamedTemp(suffix=".txt", mode="w", delete=True) as read_file:
+    with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as read_file:
         path = Path(read_file.name)
         assert_path_is_writable(path=path)
 
@@ -106,7 +105,7 @@ def test_reader(
     expected: Any,
 ) -> None:
     """Tests fgpyo.io.to_reader"""
-    with NamedTemp(suffix=suffix, mode="r", delete=True) as read_file:
+    with NamedTemporaryFile(suffix=suffix, mode="r", delete=True) as read_file:
         with fio.to_reader(path=Path(read_file.name)) as reader:
             assert isinstance(reader, expected)
 
@@ -123,7 +122,7 @@ def test_writer(
     expected: Any,
 ) -> None:
     """Tests fgpyo.io.to_writer()"""
-    with NamedTemp(suffix=suffix, mode="w", delete=True) as write_file:
+    with NamedTemporaryFile(suffix=suffix, mode="w", delete=True) as write_file:
         with fio.to_writer(path=Path(write_file.name)) as writer:
             assert isinstance(writer, expected)
 
@@ -137,7 +136,7 @@ def test_read_and_write_lines(
     list_to_write: List[Any],
 ) -> None:
     """Test fgpyo.fio.read_lines and write_lines"""
-    with NamedTemp(suffix=suffix, mode="w", delete=True) as read_file:
+    with NamedTemporaryFile(suffix=suffix, mode="w", delete=True) as read_file:
         fio.write_lines(path=Path(read_file.name), lines_to_write=list_to_write)
         read_back = fio.read_lines(path=Path(read_file.name))
         assert next(read_back) == list_to_write[0]


### PR DESCRIPTION
Closes #117 

- I updated `assert_path_is_readable()` and `assert_path_is_writable()` to specially handle `/dev/stdin` and `/dev/stdout`, respectively
- I updated `assert_path_is_readable()` to specifically require that the input `path` is a file, not just that it is not a directory. (This disparity between the two functions is why `stdin` was ok for the `readable` check, but `stdout` was not for the `writable` check)
- I lightly refactored the chain of assertions in `assert_path_is_writable()` to produce more specific error messages and for legibility.
- I updated `assert_path_is_writable()` so the absolute path is considered regardless of the value of `parent_must_exist`
- Minor housekeeping in the corresponding unit tests