### PR TITLE
feat: MetricWriter

### DIFF
--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -43,11 +43,11 @@ The functions in this module make it easy to:
 """
 
 import gzip
-import io
 import os
 import sys
 import warnings
 from contextlib import contextmanager
+from io import TextIOWrapper
 from pathlib import Path
 from typing import IO
 from typing import Any
@@ -55,8 +55,6 @@ from typing import Generator
 from typing import Iterable
 from typing import Iterator
 from typing import Set
-from typing import TextIO
-from typing import Union
 from typing import cast
 
 COMPRESSED_FILE_EXTENSIONS: Set[str] = {".gz", ".bgz"}
@@ -156,7 +154,7 @@ def assert_path_is_writable(path: Path, parent_must_exist: bool = True) -> None:
             raise AssertionError(f"No parent directories exist for: {path}")
 
 
-def to_reader(path: Path) -> Union[io.TextIOWrapper, TextIO, IO[Any]]:
+def to_reader(path: Path) -> TextIOWrapper:
     """Opens a Path for reading and based on extension uses open() or gzip.open()
 
     Args:
@@ -169,12 +167,12 @@ def to_reader(path: Path) -> Union[io.TextIOWrapper, TextIO, IO[Any]]:
 
     """
     if path.suffix in COMPRESSED_FILE_EXTENSIONS:
-        return io.TextIOWrapper(cast(IO[bytes], gzip.open(path, mode="rb")), encoding="utf-8")
+        return TextIOWrapper(cast(IO[bytes], gzip.open(path, mode="rb")), encoding="utf-8")
     else:
         return path.open(mode="r")
 
 
-def to_writer(path: Path, append: bool = False) -> Union[IO[Any], io.TextIOWrapper]:
+def to_writer(path: Path, append: bool = False) -> TextIOWrapper:
     """Opens a Path for writing (or appending) and based on extension uses open() or gzip.open()
 
     Args:
@@ -191,11 +189,11 @@ def to_writer(path: Path, append: bool = False) -> Union[IO[Any], io.TextIOWrapp
         mode_prefix = "a"
 
     if path.suffix in COMPRESSED_FILE_EXTENSIONS:
-        return io.TextIOWrapper(
+        return TextIOWrapper(
             cast(IO[bytes], gzip.open(path, mode=mode_prefix + "b")), encoding="utf-8"
         )
     else:
-        return path.open(mode=mode_prefix)
+        return cast(TextIOWrapper, path.open(mode=mode_prefix))
 
 
 def read_lines(path: Path, strip: bool = False) -> Iterator[str]:

--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -184,15 +184,18 @@ def to_writer(path: Path, append: bool = False) -> TextIOWrapper:
         >>> writer.close()
 
     """
-    mode_prefix = "w"
-    if append:
-        mode_prefix = "a"
+    mode_prefix: str = "a" if append else "w"
 
     if path.suffix in COMPRESSED_FILE_EXTENSIONS:
         return TextIOWrapper(
             cast(IO[bytes], gzip.open(path, mode=mode_prefix + "b")), encoding="utf-8"
         )
     else:
+        # NB: the `cast` here is necessary because `path.open()` may return
+        # other types, depending on the specified `mode`.
+        # Within the scope of this function, `mode_prefix` is guaranteed to be
+        # either "w" or "a", both of which result in a `TextIOWrapper`, but
+        # mypy can't follow that logic.
         return cast(TextIOWrapper, path.open(mode=mode_prefix))
 
 

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -479,7 +479,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         """
 
         filepath: Path = Path(filename)
-        ordered_fieldnames: List[str] = _validate_output_fieldnames(
+        ordered_fieldnames: List[str] = _validate_and_generate_final_output_fieldnames(
             metric_class=metric_class,
             include_fields=include_fields,
             exclude_fields=exclude_fields,
@@ -566,7 +566,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             self.write(metric)
 
 
-def _validate_output_fieldnames(
+def _validate_and_generate_final_output_fieldnames(
     metric_class: Type[MetricType],
     include_fields: Optional[List[str]] = None,
     exclude_fields: Optional[List[str]] = None,

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -142,8 +142,6 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeGuard
 
-import attr
-
 from fgpyo import io
 from fgpyo.util import inspect
 
@@ -432,11 +430,15 @@ class Metric(ABC, Generic[MetricType]):
 def _is_metric_class(cls: Any) -> TypeGuard[Metric]:
     """True if the given class is a Metric."""
 
-    return (
-        isclass(cls)
-        and issubclass(cls, Metric)
-        and (dataclasses.is_dataclass(cls) or attr.has(cls))
-    )
+    is_metric_cls: bool = isclass(cls) and issubclass(cls, Metric)
+
+    try:
+        import attr
+        is_metric_cls = is_metric_cls and (dataclasses.is_dataclass(cls) or attr.has(cls))
+    except ImportError:
+        is_metric_cls = is_metric_cls and dataclasses.is_dataclass(cls)
+
+    return is_metric_cls
 
 
 class MetricWriter(Generic[MetricType], AbstractContextManager):

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -397,7 +397,8 @@ class Metric(ABC, Generic[MetricType]):
 
         The first row after any commented or empty lines will be used as the fieldnames.
 
-        Lines preceding the fieldnames will be returned in the `preamble`.
+        Lines preceding the fieldnames will be returned in the `preamble`. Leading and trailing
+        whitespace are removed and ignored.
 
         Args:
             reader: An open, readable file handle.

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -113,8 +113,11 @@ Formatting and parsing the values for custom types is supported by overriding th
 ```
 """
 
+import dataclasses
+import sys
 from abc import ABC
 from enum import Enum
+from inspect import isclass
 from pathlib import Path
 from typing import Any
 from typing import Callable
@@ -124,8 +127,17 @@ from typing import Iterator
 from typing import List
 from typing import TypeVar
 
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extensions import TypeGuard
+
+import attr
+
 from fgpyo import io
 from fgpyo.util import inspect
+from fgpyo.util.inspect import AttrsInstance
+from fgpyo.util.inspect import DataclassInstance
 
 MetricType = TypeVar("MetricType", bound="Metric")
 
@@ -331,3 +343,65 @@ class Metric(ABC, Generic[MetricType]):
             io.write_lines(
                 path=output, lines_to_write=list(io.read_lines(input_path))[1:], append=True
             )
+
+
+def _is_dataclass_instance(metric: Metric) -> TypeGuard[DataclassInstance]:
+    """
+    Test if the given metric is a dataclass instance.
+
+    NB: `dataclasses.is_dataclass` returns True for both dataclass instances and class objects, and
+    we need to override the built-in function's `TypeGuard`.
+
+    Args:
+        metric: An instance of a Metric.
+
+    Returns:
+        True if the given metric is an instance of a dataclass-decorated Metric.
+        False otherwise.
+    """
+    return not isclass(metric) and dataclasses.is_dataclass(metric)
+
+
+def _is_attrs_instance(metric: Metric) -> TypeGuard[AttrsInstance]:
+    """
+    Test if the given metric is an attr.s instance.
+
+    NB: `attr.has` provides a type guard, but only on the class object - we want to narrow the type
+    of the metric instance, so we implement a guard here.
+
+    Args:
+        metric: An instance of a Metric.
+
+    Returns:
+        True if the given metric is an instance of an attr.s-decorated Metric.
+        False otherwise.
+    """
+    return not isclass(metric) and attr.has(metric.__class__)
+
+
+def asdict(metric: Metric) -> Dict[str, Any]:
+    """
+    Convert a Metric instance to a dictionary.
+
+    No formatting is performed on the values, and they are returned as contained (and typed) in the
+    underlying dataclass. Use `Metric.format_value` to format the values to string.
+
+    Args:
+        metric: An instance of a Metric.
+
+    Returns:
+        A dictionary representation of the given metric.
+
+    Raises:
+        TypeError: If the given metric is not an instance of a `dataclass` or `attr.s`-decorated
+        Metric.
+    """
+    if _is_dataclass_instance(metric):
+        return dataclasses.asdict(metric)
+    elif _is_attrs_instance(metric):
+        return attr.asdict(metric)
+    else:
+        raise TypeError(
+            "The provided metric is not an instance of a `dataclass` or `attr.s`-decorated Metric "
+            f"class: {metric.__class__}"
+        )

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -299,8 +299,7 @@ class Metric(ABC, Generic[MetricType]):
             values: Zero or more metrics.
 
         """
-        # TODO: open a MetricWriter here instead
-        with MetricWriter[MetricType](path, metric_class=values[0].__class__) as writer:
+        with MetricWriter[MetricType](path, metric_class=cls) as writer:
             writer.writeall(values)
 
     @classmethod

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -414,7 +414,7 @@ class Metric(ABC, Generic[MetricType]):
         preamble: List[str] = []
 
         for line in reader:
-            if line.startswith(comment_prefix) or line.strip() == "":
+            if line.strip().startswith(comment_prefix) or line.strip() == "":
                 preamble.append(line.strip())
             else:
                 break

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -178,6 +178,11 @@ class Metric(ABC, Generic[MetricType]):
     [`format_value()`][fgpyo.util.metric.Metric.format_value].
     """
 
+    def keys(self) -> Iterator[str]:
+        """An iterator over field names in the same order as the header."""
+        for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
+            yield field.name
+
     def values(self) -> Iterator[Any]:
         """An iterator over attribute values in the same order as the header."""
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -473,12 +473,16 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             AssertionError: If `append=True` and the provided file is not readable. (When appending,
                 we check to ensure that the header matches the specified metric class. The file must
                 be readable to get the header.)
+            ValueError: If `append=True` and the provided file is a FIFO (named pipe).
             ValueError: If `append=True` and the provided file does not include a header.
             ValueError: If `append=True` and the header of the provided file does not match the
                 specified metric class and the specified include/exclude fields.
         """
 
         filepath: Path = Path(filename)
+        if (filepath.is_fifo() or filepath.is_char_device()) and append:
+            raise ValueError("Cannot append to stdout, stderr, or other named pipe or stream")
+
         ordered_fieldnames: List[str] = _validate_and_generate_final_output_fieldnames(
             metric_class=metric_class,
             include_fields=include_fields,

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -116,8 +116,10 @@ Formatting and parsing the values for custom types is supported by overriding th
 import dataclasses
 import sys
 from abc import ABC
+from dataclasses import dataclass
 from enum import Enum
 from inspect import isclass
+from io import TextIOWrapper
 from pathlib import Path
 from typing import Any
 from typing import Callable
@@ -140,6 +142,23 @@ from fgpyo.util.inspect import AttrsInstance
 from fgpyo.util.inspect import DataclassInstance
 
 MetricType = TypeVar("MetricType", bound="Metric")
+
+
+@dataclass(frozen=True)
+class MetricFileHeader:
+    """
+    Header of a file.
+
+    A file's header contains an optional preamble, consisting of lines prefixed by a comment
+    character and/or empty lines, and a required row of fieldnames before the data rows begin.
+
+    Attributes:
+        preamble: A list of any lines preceding the fieldnames.
+        fieldnames: The field names specified in the final line of the header.
+    """
+
+    preamble: List[str]
+    fieldnames: List[str]
 
 
 class Metric(ABC, Generic[MetricType]):
@@ -343,6 +362,45 @@ class Metric(ABC, Generic[MetricType]):
             io.write_lines(
                 path=output, lines_to_write=list(io.read_lines(input_path))[1:], append=True
             )
+
+    @staticmethod
+    def _read_header(
+        reader: TextIOWrapper,
+        delimiter: str = "\t",
+        comment_prefix: str = "#",
+    ) -> MetricFileHeader:
+        """
+        Read the header from an open file.
+
+        The first row after any commented or empty lines will be used as the fieldnames.
+
+        Lines preceding the fieldnames will be returned in the `preamble`.
+
+        Args:
+            reader: An open, readable file handle.
+            file_format: A dataclass containing (at minimum) the file's delimiter and the string
+                prefixing any comment lines.
+
+        Returns:
+            A `MetricFileHeader` containing the field names and any preceding lines.
+
+        Raises:
+            ValueError: If the file was empty or contained only comments or empty lines.
+        """
+
+        preamble: List[str] = []
+
+        for line in reader:
+            if line.startswith(comment_prefix) or line.strip() == "":
+                preamble.append(line.strip())
+            else:
+                break
+        else:
+            raise ValueError(f"File {reader.name} did not contain a header line.")
+
+        fieldnames = line.strip().split(delimiter)
+
+        return MetricFileHeader(preamble=preamble, fieldnames=fieldnames)
 
 
 def _is_dataclass_instance(metric: Metric) -> TypeGuard[DataclassInstance]:

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -132,6 +132,7 @@ from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Type
 from typing import TypeVar
 from typing import Union
@@ -183,6 +184,10 @@ class Metric(ABC, Generic[MetricType]):
         """An iterator over attribute values in the same order as the header."""
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
             yield getattr(self, field.name)
+
+    def items(self) -> Iterator[Tuple[str, Any]]:
+        for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
+            yield (field.name, getattr(self, field.name))
 
     def formatted_values(self) -> List[str]:
         """An iterator over formatted attribute values in the same order as the header."""
@@ -726,9 +731,7 @@ def _assert_fieldnames_are_metric_attributes(
     """
     _assert_is_metric_class(metric_class)
 
-    invalid_fieldnames = {
-        f for f in specified_fieldnames if f not in _get_fieldnames(metric_class)
-    }
+    invalid_fieldnames = {f for f in specified_fieldnames if f not in _get_fieldnames(metric_class)}
 
     if len(invalid_fieldnames) > 0:
         raise ValueError(

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -488,7 +488,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         )
 
         _assert_is_metric_class(metric_class)
-        io.assert_path_is_writeable(filepath)
+        io.assert_path_is_writable(filepath)
         if append:
             io.assert_path_is_readable(filepath)
             _assert_file_header_matches_metric(

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -127,6 +127,7 @@ from typing import Dict
 from typing import Generic
 from typing import Iterator
 from typing import List
+from typing import Type
 from typing import TypeVar
 
 if sys.version_info >= (3, 10):
@@ -403,6 +404,16 @@ class Metric(ABC, Generic[MetricType]):
         return MetricFileHeader(preamble=preamble, fieldnames=fieldnames)
 
 
+def _is_metric_class(cls: Any) -> TypeGuard[Metric]:
+    """True if the given class is a Metric."""
+
+    return (
+        isclass(cls)
+        and issubclass(cls, Metric)
+        and (dataclasses.is_dataclass(cls) or attr.has(cls))
+    )
+
+
 def _is_dataclass_instance(metric: Metric) -> TypeGuard[DataclassInstance]:
     """
     Test if the given metric is a dataclass instance.
@@ -463,3 +474,98 @@ def asdict(metric: Metric) -> Dict[str, Any]:
             "The provided metric is not an instance of a `dataclass` or `attr.s`-decorated Metric "
             f"class: {metric.__class__}"
         )
+
+
+def _get_fieldnames(metric_class: Type[Metric]) -> List[str]:
+    """
+    Get the fieldnames of the specified metric class.
+
+    Args:
+        metric_class: A Metric class.
+
+    Returns:
+        A list of fieldnames.
+    """
+    _assert_is_metric_class(metric_class)
+
+    if dataclasses.is_dataclass(metric_class):
+        return [f.name for f in dataclasses.fields(metric_class)]
+    elif attr.has(metric_class):
+        return [f.name for f in attr.fields(metric_class)]
+    else:
+        assert False, "Unreachable"
+
+
+def _assert_file_header_matches_metric(
+    path: Path,
+    metric_class: Type[MetricType],
+    delimiter: str,
+) -> None:
+    """
+    Check that the specified file has a header and its fields match those of the provided Metric.
+
+    Args:
+        path: A path to a `Metric` file.
+        metric_class: The `Metric` class to validate against.
+        delimiter: The delimiter to use when reading the header.
+
+    Raises:
+        ValueError: If the provided file does not include a header.
+        ValueError: If the header of the provided file does not match the provided Metric.
+    """
+    # NB: _get_fieldnames() will validate that `metric_class` is a valid Metric class.
+    fieldnames: List[str] = _get_fieldnames(metric_class)
+
+    header: MetricFileHeader
+    with path.open("r") as fin:
+        try:
+            header = metric_class._read_header(fin, delimiter=delimiter)
+        except ValueError:
+            raise ValueError(f"Could not find a header in the provided file: {path}")
+
+    if header.fieldnames != fieldnames:
+        raise ValueError(
+            "The provided file does not have the same field names as the provided Metric:\n"
+            f"\tMetric: {metric_class.__name__}\n"
+            f"\tFile: {path}\n"
+            f"\tExpected fields: {', '.join(fieldnames)}\n"
+            f"\tActual fields: {', '.join(header.fieldnames)}\n"
+        )
+
+
+def _assert_fieldnames_are_metric_attributes(
+    specified_fieldnames: List[str],
+    metric_class: Type[MetricType],
+) -> None:
+    """
+    Check that all of the specified fields are attributes on the given Metric.
+
+    Raises:
+        ValueError: if any of the specified fieldnames are not an attribute on the given Metric.
+    """
+    _assert_is_metric_class(metric_class)
+
+    invalid_fieldnames = {
+        f for f in specified_fieldnames if f not in _get_fieldnames(metric_class)
+    }
+
+    if len(invalid_fieldnames) > 0:
+        raise ValueError(
+            "One or more of the specified fields are not attributes on the Metric "
+            + f"{metric_class.__name__}: "
+            + ", ".join(invalid_fieldnames)
+        )
+
+
+def _assert_is_metric_class(cls: Type[Metric]) -> None:
+    """
+    Assert that the given class is a Metric.
+
+    Args:
+        cls: A class object.
+
+    Raises:
+        TypeError: If the given class is not a Metric.
+    """
+    if not _is_metric_class(cls):
+        raise TypeError(f"Not a dataclass or attr decorated Metric: {cls}")

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -200,7 +200,7 @@ class Metric(ABC, Generic[MetricType]):
         """An iterator over formatted attribute values in the same order as the header."""
         return [self.format_value(value) for value in self.values()]
 
-    def formatted_items(self) -> List[str]:
+    def formatted_items(self) -> List[Tuple[str, str]]:
         """An iterator over formatted attribute values in the same order as the header."""
         return [(key, self.format_value(value)) for key, value in self.items()]
 

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -415,13 +415,15 @@ class Metric(ABC, Generic[MetricType]):
 
         for line in reader:
             if line.strip().startswith(comment_prefix) or line.strip() == "":
+                # Skip any commented or empty lines before the header
                 preamble.append(line.strip())
             else:
+                # The first line with any other content is assumed to be the header
+                fieldnames = line.strip().split(delimiter)
                 break
         else:
-            raise ValueError(f"File {reader.name} did not contain a header line.")
-
-        fieldnames = line.strip().split(delimiter)
+            # If the file was empty, kick back an empty header
+            fieldnames = []
 
         return MetricFileHeader(preamble=preamble, fieldnames=fieldnames)
 
@@ -628,7 +630,7 @@ def _assert_file_header_matches_metric(
     with path.open("r") as fin:
         header: MetricFileHeader = metric_class._read_header(fin, delimiter=delimiter)
 
-    if header is None:
+    if header.fieldnames == []:
         raise ValueError(f"Could not find a header in the provided file: {path}")
 
     fieldnames: List[str] = (

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -538,7 +538,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             raise TypeError(f"Must provide instances of {self._metric_class.__name__}")
 
         # Serialize the Metric to a dict for writing by the underlying `DictWriter`
-        row = {fieldname: self._metric_class.format_value(val) for fieldname, val in metric.items()}
+        row = {fieldname: val for fieldname, val in metric.formatted_items()}
 
         # Filter and/or re-order output fields if necessary
         row = {fieldname: row[fieldname] for fieldname in self._fieldnames}

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -595,13 +595,10 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             raise TypeError(f"Must provide instances of {self._metric_class.__name__}")
 
         # Serialize the Metric to a dict for writing by the underlying `DictWriter`
-        row = asdict(metric)
+        row = {fieldname: self._metric_class.format_value(val) for fieldname, val in metric.items()}
 
         # Filter and/or re-order output fields if necessary
         row = {fieldname: row[fieldname] for fieldname in self._fieldnames}
-
-        # Format values
-        row = {fieldname: self._metric_class.format_value(val) for fieldname, val in row.items()}
 
         self._writer.writerow(row)
 

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -116,19 +116,25 @@ Formatting and parsing the values for custom types is supported by overriding th
 import dataclasses
 import sys
 from abc import ABC
+from contextlib import AbstractContextManager
+from csv import DictWriter
 from dataclasses import dataclass
 from enum import Enum
 from inspect import isclass
 from io import TextIOWrapper
 from pathlib import Path
+from types import TracebackType
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Generic
+from typing import Iterable
 from typing import Iterator
 from typing import List
+from typing import Optional
 from typing import Type
 from typing import TypeVar
+from typing import Union
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -476,6 +482,140 @@ def asdict(metric: Metric) -> Dict[str, Any]:
         )
 
 
+class MetricWriter(Generic[MetricType], AbstractContextManager):
+    _metric_class: Type[Metric]
+    _fieldnames: List[str]
+    _fout: TextIOWrapper
+    _writer: DictWriter
+
+    def __init__(
+        self,
+        filename: Union[Path, str],
+        metric_class: Type[Metric],
+        append: bool = False,
+        delimiter: str = "\t",
+        include_fields: Optional[List[str]] = None,
+        exclude_fields: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Args:
+            path: Path to the file to write.
+            metric_class: Metric class.
+            append: If `True`, the file will be appended to. Otherwise, the specified file will be
+                overwritten.
+            delimiter: The output file delimiter.
+            include_fields: If specified, only the listed fieldnames will be included when writing
+                records to file. Fields will be written in the order provided.
+                May not be used together with `exclude_fields`.
+            exclude_fields: If specified, any listed fieldnames will be excluded when writing
+                records to file.
+                May not be used together with `include_fields`.
+
+        Raises:
+            TypeError: If the provided metric class is not a dataclass- or attr-decorated
+                subclass of `Metric`.
+            AssertionError: If the provided filepath is not writable.
+            AssertionError: If `append=True` and the provided file is not readable. (When appending,
+                we check to ensure that the header matches the specified metric class. The file must
+                be readable to get the header.)
+            ValueError: If `append=True` and the provided file does not include a header.
+            ValueError: If `append=True` and the header of the provided file does not match the
+                specified metric class and the specified include/exclude fields.
+        """
+
+        filepath: Path = Path(filename)
+        ordered_fieldnames: List[str] = _validate_output_fieldnames(
+            metric_class=metric_class,
+            include_fields=include_fields,
+            exclude_fields=exclude_fields,
+        )
+
+        _assert_is_metric_class(metric_class)
+        io.assert_path_is_writeable(filepath)
+        if append:
+            io.assert_path_is_readable(filepath)
+            _assert_file_header_matches_metric(
+                path=filepath,
+                metric_class=metric_class,
+                ordered_fieldnames=ordered_fieldnames,
+                delimiter=delimiter,
+            )
+
+        self._metric_class = metric_class
+        self._fieldnames = ordered_fieldnames
+        self._fout = io.to_writer(filepath, append=append)
+        self._writer = DictWriter(
+            f=self._fout,
+            fieldnames=self._fieldnames,
+            delimiter=delimiter,
+        )
+
+        # If we aren't appending to an existing file, write the header before any rows
+        if not append:
+            self._writer.writeheader()
+
+    def __enter__(self) -> "MetricWriter":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_value: BaseException,
+        traceback: TracebackType,
+    ) -> None:
+        self.close()
+        super().__exit__(exc_type, exc_value, traceback)
+
+    def close(self) -> None:
+        """Close the underlying file handle."""
+        self._fout.close()
+
+    def write(self, metric: Metric) -> None:
+        """
+        Write a single Metric instance to file.
+
+        The Metric is converted to a dictionary and then written using the underlying
+        `csv.DictWriter`. If the `MetricWriter` was created using the `include_fields` or
+        `exclude_fields` arguments, the fields of the Metric are subset and/or reordered
+        accordingly before writing.
+
+        Args:
+            metric: An instance of the specified Metric.
+
+        Raises:
+            TypeError: If the provided `metric` is not an instance of the Metric class used to
+            parametrize the writer.
+        """
+        if not isinstance(metric, self._metric_class):
+            raise TypeError(f"Must provide instances of {self._metric_class.__name__}")
+
+        # Serialize the Metric to a dict for writing by the underlying `DictWriter`
+        row = asdict(metric)
+
+        # Filter and/or re-order output fields if necessary
+        row = {fieldname: row[fieldname] for fieldname in self._fieldnames}
+
+        # Format values
+        row = {fieldname: self._metric_class.format_value(val) for fieldname, val in row.items()}
+
+        self._writer.writerow(row)
+
+    def writeall(self, metrics: Iterable[Metric]) -> None:
+        """
+        Write multiple Metric instances to file.
+
+        Each Metric is converted to a dictionary and then written using the underlying
+        `csv.DictWriter`. If the `MetricWriter` was created using the `include_fields` or
+        `exclude_fields` arguments, the attributes of each Metric are subset and/or reordered
+        accordingly before writing.
+
+        Args:
+            metrics: A sequence of instances of the specified Metric.
+        """
+        for metric in metrics:
+            self.write(metric)
+
+
 def _get_fieldnames(metric_class: Type[Metric]) -> List[str]:
     """
     Get the fieldnames of the specified metric class.
@@ -496,10 +636,47 @@ def _get_fieldnames(metric_class: Type[Metric]) -> List[str]:
         assert False, "Unreachable"
 
 
+def _validate_output_fieldnames(
+    metric_class: Type[MetricType],
+    include_fields: Optional[List[str]] = None,
+    exclude_fields: Optional[List[str]] = None,
+) -> List[str]:
+    """
+    Subset and/or re-order the Metric's fieldnames based on the specified include/exclude lists.
+
+    * Only one of `include_fields` and `exclude_fields` may be specified.
+    * All fieldnames specified in `include_fields` must be fields on `metric_class`. If this
+      argument is specified, fields will be returned in the order they appear in the list.
+    * All fieldnames specified in `exclude_fields` must be fields on `metric_class`. (This is
+      technically unnecessary, but is a safeguard against passing an incorrect list.)
+    * If neither `include_fields` or `exclude_fields` are specified, return the `metric_class`'s
+      fieldnames, in the order they are defined on the `metric_class`.
+
+    Raises:
+        ValueError: If both `include_fields` and `exclude_fields` are specified.
+    """
+
+    if include_fields is not None and exclude_fields is not None:
+        raise ValueError(
+            "Only one of `include_fields` and `exclude_fields` may be specified, not both."
+        )
+    elif exclude_fields is not None:
+        _assert_fieldnames_are_metric_attributes(exclude_fields, metric_class)
+        output_fieldnames = [f for f in _get_fieldnames(metric_class) if f not in exclude_fields]
+    elif include_fields is not None:
+        _assert_fieldnames_are_metric_attributes(include_fields, metric_class)
+        output_fieldnames = include_fields
+    else:
+        output_fieldnames = _get_fieldnames(metric_class)
+
+    return output_fieldnames
+
+
 def _assert_file_header_matches_metric(
     path: Path,
     metric_class: Type[MetricType],
     delimiter: str,
+    ordered_fieldnames: Optional[List[str]] = None,
 ) -> None:
     """
     Check that the specified file has a header and its fields match those of the provided Metric.
@@ -508,20 +685,24 @@ def _assert_file_header_matches_metric(
         path: A path to a `Metric` file.
         metric_class: The `Metric` class to validate against.
         delimiter: The delimiter to use when reading the header.
+        ordered_fieldnames: An optional ordering of the fieldnames in the header.
 
     Raises:
         ValueError: If the provided file does not include a header.
-        ValueError: If the header of the provided file does not match the provided Metric.
+        ValueError: If the header of the provided file does not match the provided Metric (or list
+            of ordered fieldnames, if provided).
     """
-    # NB: _get_fieldnames() will validate that `metric_class` is a valid Metric class.
-    fieldnames: List[str] = _get_fieldnames(metric_class)
+    _assert_is_metric_class(metric_class)
 
-    header: MetricFileHeader
     with path.open("r") as fin:
-        try:
-            header = metric_class._read_header(fin, delimiter=delimiter)
-        except ValueError:
-            raise ValueError(f"Could not find a header in the provided file: {path}")
+        header: MetricFileHeader = metric_class._read_header(fin, delimiter=delimiter)
+
+    if header is None:
+        raise ValueError(f"Could not find a header in the provided file: {path}")
+
+    fieldnames: List[str] = (
+        ordered_fieldnames if ordered_fieldnames is not None else _get_fieldnames(metric_class)
+    )
 
     if header.fieldnames != fieldnames:
         raise ValueError(

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -456,7 +456,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
     ) -> None:
         """
         Args:
-            path: Path to the file to write.
+            filename: Path to the file to write.
             metric_class: Metric class.
             append: If `True`, the file will be appended to. Otherwise, the specified file will be
                 overwritten.
@@ -541,7 +541,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
 
         Raises:
             TypeError: If the provided `metric` is not an instance of the Metric class used to
-            parametrize the writer.
+                parametrize the writer.
         """
         if not isinstance(metric, self._metric_class):
             raise TypeError(f"Must provide instances of {self._metric_class.__name__}")

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -300,14 +300,8 @@ class Metric(ABC, Generic[MetricType]):
 
         """
         # TODO: open a MetricWriter here instead
-        with io.to_writer(path) as writer:
-            writer.write("\t".join(cls.header()))
-            writer.write("\n")
-            for value in values:
-                # Important, don't recurse on nested attr classes, instead let implementing class
-                # implement format_value.
-                writer.write("\t".join(cls.format_value(item) for item in value.values()))
-                writer.write("\n")
+        with MetricWriter[MetricType](path, metric_class=values[0].__class__) as writer:
+            writer.writeall(values)
 
     @classmethod
     def header(cls) -> List[str]:

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -184,12 +184,19 @@ class Metric(ABC, Generic[MetricType]):
             yield getattr(self, field.name)
 
     def items(self) -> Iterator[Tuple[str, Any]]:
+        """
+        An iterator over field names and their corresponding values in the same order as the header.
+        """
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
             yield (field.name, getattr(self, field.name))
 
     def formatted_values(self) -> List[str]:
         """An iterator over formatted attribute values in the same order as the header."""
         return [self.format_value(value) for value in self.values()]
+
+    def formatted_items(self) -> List[str]:
+        """An iterator over formatted attribute values in the same order as the header."""
+        return [(key, self.format_value(value)) for key, value in self.items()]
 
     @classmethod
     def _parsers(cls) -> Dict[type, Callable[[str], Any]]:

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -146,8 +146,6 @@ import attr
 
 from fgpyo import io
 from fgpyo.util import inspect
-from fgpyo.util.inspect import AttrsInstance
-from fgpyo.util.inspect import DataclassInstance
 
 MetricType = TypeVar("MetricType", bound="Metric")
 
@@ -423,68 +421,6 @@ def _is_metric_class(cls: Any) -> TypeGuard[Metric]:
         and issubclass(cls, Metric)
         and (dataclasses.is_dataclass(cls) or attr.has(cls))
     )
-
-
-def _is_dataclass_instance(metric: Metric) -> TypeGuard[DataclassInstance]:
-    """
-    Test if the given metric is a dataclass instance.
-
-    NB: `dataclasses.is_dataclass` returns True for both dataclass instances and class objects, and
-    we need to override the built-in function's `TypeGuard`.
-
-    Args:
-        metric: An instance of a Metric.
-
-    Returns:
-        True if the given metric is an instance of a dataclass-decorated Metric.
-        False otherwise.
-    """
-    return not isclass(metric) and dataclasses.is_dataclass(metric)
-
-
-def _is_attrs_instance(metric: Metric) -> TypeGuard[AttrsInstance]:
-    """
-    Test if the given metric is an attr.s instance.
-
-    NB: `attr.has` provides a type guard, but only on the class object - we want to narrow the type
-    of the metric instance, so we implement a guard here.
-
-    Args:
-        metric: An instance of a Metric.
-
-    Returns:
-        True if the given metric is an instance of an attr.s-decorated Metric.
-        False otherwise.
-    """
-    return not isclass(metric) and attr.has(metric.__class__)
-
-
-def asdict(metric: Metric) -> Dict[str, Any]:
-    """
-    Convert a Metric instance to a dictionary.
-
-    No formatting is performed on the values, and they are returned as contained (and typed) in the
-    underlying dataclass. Use `Metric.format_value` to format the values to string.
-
-    Args:
-        metric: An instance of a Metric.
-
-    Returns:
-        A dictionary representation of the given metric.
-
-    Raises:
-        TypeError: If the given metric is not an instance of a `dataclass` or `attr.s`-decorated
-        Metric.
-    """
-    if _is_dataclass_instance(metric):
-        return dataclasses.asdict(metric)
-    elif _is_attrs_instance(metric):
-        return attr.asdict(metric)
-    else:
-        raise TypeError(
-            "The provided metric is not an instance of a `dataclass` or `attr.s`-decorated Metric "
-            f"class: {metric.__class__}"
-        )
 
 
 class MetricWriter(Generic[MetricType], AbstractContextManager):

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -767,11 +767,7 @@ def test_assert_is_metric_class(data_and_classes: DataBuilder) -> None:
     """
     Test that we can validate if a class is a Metric.
     """
-    try:
-        _assert_is_metric_class(data_and_classes.DummyMetric)
-    except TypeError:
-        raise AssertionError("Failed to validate a valid Metric") from None
-
+    _assert_is_metric_class(data_and_classes.DummyMetric)
 
 def test_assert_is_metric_class_raises_if_not_decorated() -> None:
     """

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -4,6 +4,7 @@
 import enum
 import gzip
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from typing import Callable
@@ -29,6 +30,10 @@ import pytest
 from fgpyo.util.inspect import is_attr_class
 from fgpyo.util.inspect import is_dataclasses_class
 from fgpyo.util.metric import Metric
+from fgpyo.util.metric import _assert_fieldnames_are_metric_attributes
+from fgpyo.util.metric import _assert_file_header_matches_metric
+from fgpyo.util.metric import _assert_is_metric_class
+from fgpyo.util.metric import _get_fieldnames
 from fgpyo.util.metric import _is_attrs_instance
 from fgpyo.util.metric import _is_dataclass_instance
 from fgpyo.util.metric import asdict
@@ -590,3 +595,154 @@ def test_read_header_can_read_picard(tmp_path: Path) -> None:
         header = Metric._read_header(metrics_file, comment_prefix="#")
 
     assert header.fieldnames == ["SAMPLE", "FOO", "BAR"]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_get_fieldnames(data_and_classes: DataBuilder) -> None:
+    """Test we can get the fieldnames of a metric."""
+
+    assert _get_fieldnames(data_and_classes.Person) == ["name", "age"]
+
+
+def test_fieldnames_raises_if_not_a_metric() -> None:
+    """Test we raise if we get a non-metric."""
+
+    @dataclass
+    class BadMetric:
+        foo: str
+        bar: int
+
+    with pytest.raises(TypeError, match="Not a dataclass or attr decorated Metric"):
+        _get_fieldnames(BadMetric)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_assert_is_metric_class(data_and_classes: DataBuilder) -> None:
+    """
+    Test that we can validate if a class is a Metric.
+    """
+    try:
+        _assert_is_metric_class(data_and_classes.DummyMetric)
+    except TypeError:
+        raise AssertionError("Failed to validate a valid Metric") from None
+
+
+def test_assert_is_metric_class_raises_if_not_decorated() -> None:
+    """
+    Test that we raise an error if the provided type is a Metric subclass but not decorated as a
+    dataclass or attr.
+    """
+
+    class BadMetric(Metric["BadMetric"]):
+        foo: str
+        bar: int
+
+    with pytest.raises(TypeError, match="Not a dataclass or attr decorated Metric"):
+        _assert_is_metric_class(BadMetric)
+
+
+def test_assert_is_metric_class_raises_if_not_a_metric() -> None:
+    """
+    Test that we raise an error if the provided type is decorated as a
+    dataclass or attr but does not subclass Metric.
+    """
+
+    @dataclass
+    class BadMetric:
+        foo: str
+        bar: int
+
+    with pytest.raises(TypeError, match="Not a dataclass or attr decorated Metric"):
+        _assert_is_metric_class(BadMetric)
+
+    @attr.s
+    class BadMetric:
+        foo: str
+        bar: int
+
+    with pytest.raises(TypeError, match="Not a dataclass or attr decorated Metric"):
+        _assert_is_metric_class(BadMetric)
+
+
+# fmt: off
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+@pytest.mark.parametrize(
+    "fieldnames",
+    [
+        ["name", "age"],  # The fieldnames are all the attributes of the provided metric
+        ["age", "name"],  # The fieldnames are out of order
+        ["name"],         # The fieldnames are a subset of the attributes of the provided metric
+    ],
+)
+# fmt: on
+def test_assert_fieldnames_are_metric_attributes(
+    data_and_classes: DataBuilder,
+    fieldnames: List[str],
+) -> None:
+    """
+    Should not raise an error if the provided fieldnames are all attributes of the provided metric.
+    """
+    try:
+        _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
+    except Exception:
+        raise AssertionError("Fieldnames should be valid") from None
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+@pytest.mark.parametrize(
+    "fieldnames",
+    [
+        ["name", "age", "foo"],
+        ["name", "foo"],
+        ["foo", "name", "age"],
+        ["foo"],
+    ],
+)
+def test_assert_fieldnames_are_metric_attributes_raises(
+    data_and_classes: DataBuilder,
+    fieldnames: List[str],
+) -> None:
+    """
+    Should raise an error if any of the provided fieldnames are not an attribute on the metric.
+    """
+    with pytest.raises(ValueError, match="One or more of the specified fields are not "):
+        _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_assert_file_header_matches_metric(tmp_path: Path, data_and_classes: DataBuilder) -> None:
+    """
+    Should not raise an error if the provided file header matches the provided metric.
+    """
+    metric_path = tmp_path / "metrics.tsv"
+    with metric_path.open("w") as metrics_file:
+        metrics_file.write("name\tage\n")
+
+    try:
+        _assert_file_header_matches_metric(metric_path, data_and_classes.Person, delimiter="\t")
+    except Exception:
+        raise AssertionError("File header should be valid") from None
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+@pytest.mark.parametrize(
+    "header",
+    [
+        ["name"],
+        ["age"],
+        ["name", "age", "foo"],
+        ["foo", "name", "age"],
+    ],
+)
+def test_assert_file_header_matches_metric_raises(
+    tmp_path: Path, data_and_classes: DataBuilder, header: List[str]
+) -> None:
+    """
+    Should raise an error if the provided file header does not match the provided metric.
+    """
+    metric_path = tmp_path / "metrics.tsv"
+    with metric_path.open("w") as metrics_file:
+        metrics_file.write("\t".join(header) + "\n")
+
+    with pytest.raises(ValueError, match="The provided file does not have the same field names"):
+        _assert_file_header_matches_metric(metric_path, data_and_classes.Person, delimiter="\t")

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -393,6 +393,11 @@ def test_metric_header(data_and_classes: DataBuilder) -> None:
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_keys(data_and_classes: DataBuilder) -> None:
+    assert list(data_and_classes.Person(name="Fulcrum", age=9).keys()) == ["name", "age"]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_values(data_and_classes: DataBuilder) -> None:
     assert list(data_and_classes.Person(name="name", age=42).values()) == ["name", 42]
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -416,6 +416,12 @@ def test_metric_formatted_values(data_and_classes: DataBuilder) -> None:
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_formatted_items(data_and_classes: DataBuilder) -> None:
+    items = data_and_classes.Person(name="Fulcrum", age=9).formatted_items()
+    assert items == [("name", "Fulcrum"), ("age", "9")]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_custom_parser(data_and_classes: DataBuilder) -> None:
     NamedPerson: TypeAlias = data_and_classes.NamedPerson
     assert NamedPerson.parse(fields=["john doe", "42"]) == (

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -35,9 +35,6 @@ from fgpyo.util.metric import _assert_fieldnames_are_metric_attributes
 from fgpyo.util.metric import _assert_file_header_matches_metric
 from fgpyo.util.metric import _assert_is_metric_class
 from fgpyo.util.metric import _get_fieldnames
-from fgpyo.util.metric import _is_attrs_instance
-from fgpyo.util.metric import _is_dataclass_instance
-from fgpyo.util.metric import asdict
 
 
 class EnumTest(enum.Enum):
@@ -535,52 +532,6 @@ def test_metric_columns_out_of_order(tmp_path: Path, data_and_classes: DataBuild
     names = list(NameMetric.read(path=path))
     assert len(names) == 1
     assert names[0] == name
-
-
-def test_is_dataclass_instance() -> None:
-    """Test that _is_dataclass_instance works as expected."""
-
-    # True for `dataclass`-decorated instances but not `attr.s`-decorated instances
-    assert _is_dataclass_instance(dataclasses_data_and_classes.Person(name="name", age=42))
-    assert not _is_dataclass_instance(attr_data_and_classes.Person(name="name", age=42))
-
-    # And False for both classes
-    assert not _is_dataclass_instance(dataclasses_data_and_classes.Person)
-    assert not _is_dataclass_instance(attr_data_and_classes.Person)
-
-
-def test_is_attrs_instance() -> None:
-    """Test that _is_attrs_instance works as expected."""
-
-    # True for `attr.s`-decorated instances but not `dataclass`-decorated instances
-    assert not _is_attrs_instance(dataclasses_data_and_classes.Person(name="name", age=42))
-    assert _is_attrs_instance(attr_data_and_classes.Person(name="name", age=42))
-
-    # And False for both classes
-    assert not _is_attrs_instance(dataclasses_data_and_classes.Person)
-    assert not _is_attrs_instance(attr_data_and_classes.Person)
-
-
-@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
-def test_asdict(data_and_classes: DataBuilder) -> None:
-    """Test that asdict works as expected on both dataclass and attr.s decoreated metrics."""
-
-    assert asdict(data_and_classes.Person(name="name", age=42)) == {"name": "name", "age": 42}
-
-
-def test_asdict_raises() -> None:
-    """Test that we raise a TypeError when asdict is called on a non-metric class."""
-
-    class UndecoratedMetric(Metric["UndecoratedMetric"]):
-        foo: int
-        bar: str
-
-        def __init__(self, foo: int, bar: str):
-            self.foo = foo
-            self.bar = bar
-
-    with pytest.raises(TypeError, match="The provided metric is not an instance"):
-        asdict(UndecoratedMetric(foo=1, bar="a"))
 
 
 def test_read_header_can_read_picard(tmp_path: Path) -> None:

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -30,9 +30,9 @@ import pytest
 from fgpyo.util.inspect import is_attr_class
 from fgpyo.util.inspect import is_dataclasses_class
 from fgpyo.util.metric import Metric
+from fgpyo.util.metric import MetricWriter
 from fgpyo.util.metric import _assert_fieldnames_are_metric_attributes
 from fgpyo.util.metric import _assert_file_header_matches_metric
-from fgpyo.util.metric import MetricWriter
 from fgpyo.util.metric import _assert_is_metric_class
 from fgpyo.util.metric import _get_fieldnames
 from fgpyo.util.metric import _is_attrs_instance
@@ -398,6 +398,13 @@ def test_metric_header(data_and_classes: DataBuilder) -> None:
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_values(data_and_classes: DataBuilder) -> None:
     assert list(data_and_classes.Person(name="name", age=42).values()) == ["name", 42]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_items(data_and_classes: DataBuilder) -> None:
+    """`metric.items()` should return a list of (key, value) tuples."""
+    items = list(data_and_classes.Person(name="Fulcrum", age=9).items())
+    assert items == [("name", "Fulcrum"), ("age", 9)]
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -3,6 +3,7 @@
 # mypy: ignore-errors
 import enum
 import gzip
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -765,6 +766,9 @@ def test_writer_exclude_fields(tmp_path: Path) -> None:
 
 def test_writer_raises_if_fifo(capsys: CaptureFixture) -> None:
     """MetricWriter should raise an error if we try to append to a FIFO."""
+    if os.name == "nt":
+        pytest.skip("Test requires Unix-like operating system")
+
     with pytest.raises(
         ValueError, match="Cannot append to stdout, stderr, or other named pipe or stream"
     ):

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -26,6 +26,7 @@ import dataclasses
 
 import attr
 import pytest
+from pytest import CaptureFixture
 
 from fgpyo.util.inspect import is_attr_class
 from fgpyo.util.inspect import is_dataclasses_class
@@ -760,6 +761,15 @@ def test_writer_exclude_fields(tmp_path: Path) -> None:
         assert next(f) == "def\n"
         with pytest.raises(StopIteration):
             next(f)
+
+
+def test_writer_raises_if_fifo(capsys: CaptureFixture) -> None:
+    """MetricWriter should raise an error if we try to append to a FIFO."""
+    with pytest.raises(
+        ValueError, match="Cannot append to stdout, stderr, or other named pipe or stream"
+    ):
+        with capsys.disabled():
+            MetricWriter(filename="/dev/stdout", metric_class=FakeMetric, append=True)
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -34,7 +34,6 @@ from fgpyo.util.metric import MetricWriter
 from fgpyo.util.metric import _assert_fieldnames_are_metric_attributes
 from fgpyo.util.metric import _assert_file_header_matches_metric
 from fgpyo.util.metric import _assert_is_metric_class
-from fgpyo.util.metric import _get_fieldnames
 
 
 class EnumTest(enum.Enum):
@@ -746,25 +745,6 @@ def test_writer_exclude_fields(tmp_path: Path) -> None:
         assert next(f) == "def\n"
         with pytest.raises(StopIteration):
             next(f)
-
-
-@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
-def test_get_fieldnames(data_and_classes: DataBuilder) -> None:
-    """Test we can get the fieldnames of a metric."""
-
-    assert _get_fieldnames(data_and_classes.Person) == ["name", "age"]
-
-
-def test_fieldnames_raises_if_not_a_metric() -> None:
-    """Test we raise if we get a non-metric."""
-
-    @dataclass
-    class BadMetric:
-        foo: str
-        bar: int
-
-    with pytest.raises(TypeError, match="Not a dataclass or attr decorated Metric"):
-        _get_fieldnames(BadMetric)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -568,3 +568,25 @@ def test_asdict_raises() -> None:
 
     with pytest.raises(TypeError, match="The provided metric is not an instance"):
         asdict(UndecoratedMetric(foo=1, bar="a"))
+
+
+def test_read_header_can_read_picard(tmp_path: Path) -> None:
+    """
+    Test that we can read the header of a picard-formatted file.
+    """
+
+    metrics_path = tmp_path / "fake_picard_metrics"
+
+    with metrics_path.open("w") as metrics_file:
+        metrics_file.write("## htsjdk.samtools.metrics.StringHeader\n")
+        metrics_file.write("# hts.fake_tool.FakeTool INPUT=input OUTPUT=fake_picard_metrics\n")
+        metrics_file.write("## htsjdk.samtools.metrics.StringHeader\n")
+        metrics_file.write("# Started on: Mon Jul 03 18:06:02 UTC 2017\n")
+        metrics_file.write("\n")
+        metrics_file.write("## METRICS CLASS\tpicard.analysis.FakeMetrics\n")
+        metrics_file.write("SAMPLE\tFOO\tBAR\n")
+
+    with metrics_path.open("r") as metrics_file:
+        header = Metric._read_header(metrics_file, comment_prefix="#")
+
+    assert header.fieldnames == ["SAMPLE", "FOO", "BAR"]

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -769,6 +769,7 @@ def test_assert_is_metric_class(data_and_classes: DataBuilder) -> None:
     """
     _assert_is_metric_class(data_and_classes.DummyMetric)
 
+
 def test_assert_is_metric_class_raises_if_not_decorated() -> None:
     """
     Test that we raise an error if the provided type is a Metric subclass but not decorated as a
@@ -821,7 +822,10 @@ def test_assert_fieldnames_are_metric_attributes(
     data_and_classes: DataBuilder,
     fieldnames: List[str],
 ) -> None:
-    """Should not raise an error if the provided fieldnames are all attributes of the provided metric."""
+    """
+    Should not raise an error if the provided fieldnames are all attributes of
+    the provided metric.
+    """
     _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -825,14 +825,8 @@ def test_assert_fieldnames_are_metric_attributes(
     data_and_classes: DataBuilder,
     fieldnames: List[str],
 ) -> None:
-    """
-    Should not raise an error if the provided fieldnames are all attributes of the provided metric.
-    """
-    try:
-        _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
-    except Exception:
-        raise AssertionError("Fieldnames should be valid") from None
-
+    """Should not raise an error if the provided fieldnames are all attributes of the provided metric."""
+    _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 @pytest.mark.parametrize(

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -566,6 +566,21 @@ def test_read_header_can_read_picard(tmp_path: Path) -> None:
     assert header.fieldnames == ["SAMPLE", "FOO", "BAR"]
 
 
+def test_read_header_can_read_empty(tmp_path: Path) -> None:
+    """
+    If the input file is empty, we should get an empty header.
+    """
+
+    metrics_path = tmp_path / "empty"
+    metrics_path.touch()
+
+    with metrics_path.open("r") as metrics_file:
+        header = Metric._read_header(metrics_file, comment_prefix="#")
+
+    assert header.preamble == []
+    assert header.fieldnames == []
+
+
 @dataclass
 class FakeMetric(Metric["FakeMetric"]):
     foo: str
@@ -643,7 +658,7 @@ def test_writer_append_raises_if_empty(tmp_path: Path) -> None:
     fpath = tmp_path / "test.txt"
     fpath.touch()
 
-    with pytest.raises(ValueError, match=f"File {fpath} did not contain a header line"):
+    with pytest.raises(ValueError, match="Could not find a header in the provided file"):
         with MetricWriter(filename=fpath, append=True, metric_class=FakeMetric) as writer:
             writer.write(FakeMetric(foo="abc", bar=1))
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -864,11 +864,7 @@ def test_assert_file_header_matches_metric(tmp_path: Path, data_and_classes: Dat
     with metric_path.open("w") as metrics_file:
         metrics_file.write("name\tage\n")
 
-    try:
-        _assert_file_header_matches_metric(metric_path, data_and_classes.Person, delimiter="\t")
-    except Exception:
-        raise AssertionError("File header should be valid") from None
-
+    _assert_file_header_matches_metric(metric_path, data_and_classes.Person, delimiter="\t")
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #88 
Closes #90 

## Summary

This PR introduces a `MetricWriter` class. 

This PR is motivated by a limitation in `Metric.write()`, which does not permit appending metric instances to a file. The new class supports appending and streamed writing of metrics, validating that the existing file's structure matches the metrics being written. `MetricWriter` also supports optionally reordering or removing fields when writing.

## Added

- Added the `MetricWriter` class, which supports context-managed appending and writing of Metrics to file.
- Added `Metric.keys()`, `Metric.items()`, and `Metric.formatted_items()`. These are companions to the existing `Metric.values()` and `Metric.formatted_values()`, and provide analogous key/item views
- Added `Metric._read_header` and the associated `MetricFileHeader` class, to parse a file's header (and any preceding comment lines). 
    - NB: This code is employed in #103 to support reading of Picard-style metrics files.