### PR TITLE
feat: Add `read_header()`

### DIFF
--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -160,8 +160,8 @@ class MetricFileHeader:
         fieldnames: The field names specified in the final line of the header.
     """
 
-    preface: list[str]
-    fieldnames: list[str]
+    preface: List[str]
+    fieldnames: List[str]
 
 
 class Metric(ABC, Generic[MetricType]):
@@ -391,7 +391,7 @@ class Metric(ABC, Generic[MetricType]):
             ValueError: If the file was empty or contained only comments or empty lines.
         """
 
-        preface: list[str] = []
+        preface: List[str] = []
 
         for line in reader:
             if line.startswith(comment_prefix) or line.strip() == "":

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -147,7 +147,7 @@ from fgpyo.util.inspect import DataclassInstance
 MetricType = TypeVar("MetricType", bound="Metric")
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True)
 class MetricFileHeader:
     """
     Header of a file.

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -152,15 +152,15 @@ class MetricFileHeader:
     """
     Header of a file.
 
-    A file's header contains an optional preface, consisting of lines prefixed by a comment
+    A file's header contains an optional preamble, consisting of lines prefixed by a comment
     character and/or empty lines, and a required row of fieldnames before the data rows begin.
 
     Attributes:
-        preface: A list of any lines preceding the fieldnames.
+        preamble: A list of any lines preceding the fieldnames.
         fieldnames: The field names specified in the final line of the header.
     """
 
-    preface: List[str]
+    preamble: List[str]
     fieldnames: List[str]
 
 
@@ -367,7 +367,7 @@ class Metric(ABC, Generic[MetricType]):
             )
 
     @staticmethod
-    def read_header(
+    def _read_header(
         reader: TextIOWrapper,
         delimiter: str = "\t",
         comment_prefix: str = "#",
@@ -377,7 +377,7 @@ class Metric(ABC, Generic[MetricType]):
 
         The first row after any commented or empty lines will be used as the fieldnames.
 
-        Lines preceding the fieldnames will be returned in the `preface`.
+        Lines preceding the fieldnames will be returned in the `preamble`.
 
         Args:
             reader: An open, readable file handle.
@@ -385,17 +385,17 @@ class Metric(ABC, Generic[MetricType]):
                 prefixing any comment lines.
 
         Returns:
-            A `FileHeader` containing the field names and any preceding lines.
+            A `MetricFileHeader` containing the field names and any preceding lines.
 
         Raises:
             ValueError: If the file was empty or contained only comments or empty lines.
         """
 
-        preface: List[str] = []
+        preamble: List[str] = []
 
         for line in reader:
             if line.startswith(comment_prefix) or line.strip() == "":
-                preface.append(line.strip())
+                preamble.append(line.strip())
             else:
                 break
         else:
@@ -403,7 +403,7 @@ class Metric(ABC, Generic[MetricType]):
 
         fieldnames = line.strip().split(delimiter)
 
-        return MetricFileHeader(preface=preface, fieldnames=fieldnames)
+        return MetricFileHeader(preamble=preamble, fieldnames=fieldnames)
 
 
 def _is_dataclass_instance(metric: Metric) -> TypeGuard[DataclassInstance]:

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -568,3 +568,25 @@ def test_asdict_raises() -> None:
 
     with pytest.raises(TypeError, match="The provided metric is not an instance"):
         asdict(UndecoratedMetric(foo=1, bar="a"))
+
+
+def test_read_header_can_read_picard(tmp_path: Path) -> None:
+    """
+    Test that we can read the header of a picard-formatted file.
+    """
+
+    metrics_path = tmp_path / "fake_picard_metrics"
+
+    with metrics_path.open("w") as metrics_file:
+        metrics_file.write("## htsjdk.samtools.metrics.StringHeader\n")
+        metrics_file.write("# hts.fake_tool.FakeTool INPUT=input OUTPUT=fake_picard_metrics\n")
+        metrics_file.write("## htsjdk.samtools.metrics.StringHeader\n")
+        metrics_file.write("# Started on: Mon Jul 03 18:06:02 UTC 2017\n")
+        metrics_file.write("\n")
+        metrics_file.write("## METRICS CLASS\tpicard.analysis.FakeMetrics\n")
+        metrics_file.write("SAMPLE\tFOO\tBAR\n")
+
+    with metrics_path.open("r") as metrics_file:
+        header = Metric.read_header(metrics_file, comment_prefix="#")
+
+    assert header.fieldnames == ["SAMPLE", "FOO", "BAR"]

--- a/fgpyo/util/tests/test_metric.py
+++ b/fgpyo/util/tests/test_metric.py
@@ -587,6 +587,6 @@ def test_read_header_can_read_picard(tmp_path: Path) -> None:
         metrics_file.write("SAMPLE\tFOO\tBAR\n")
 
     with metrics_path.open("r") as metrics_file:
-        header = Metric.read_header(metrics_file, comment_prefix="#")
+        header = Metric._read_header(metrics_file, comment_prefix="#")
 
     assert header.fieldnames == ["SAMPLE", "FOO", "BAR"]


### PR DESCRIPTION
@nh13 @tfenne @clintval 

I'm breaking up #107 into a few smaller PRs.

This one introduces the `read_header()` function, which I've implemented as a static method on `Metric`.

This may look familiar, and I apologize for the duplication - similar functionality has shown up in both #107 and #103. I've incorporated the feedback left on both PRs, and would like to consolidate on this PR (with the others to be based off this one). 

The purpose of the `read_header()` function is two-fold: 1) to support the incoming `MetricWriter` class, and 2) to generalize `Metric.read` to support files with lines preceding the header (e.g. Picard metric files).

I'm introducing a dataclass to contain both the detected fieldnames and any preceding lines, so if we choose we can write metric files with the same header as an input file (including preceding comment lines). If this falls under YAGNI, lmk and I can update `read_header()` to simply return the list of fieldnames