### PR TITLE
chore: fix B017 violations

### DIFF
--- a/fgpyo/fasta/tests/test_builder.py
+++ b/fgpyo/fasta/tests/test_builder.py
@@ -45,7 +45,7 @@ def test_bases_length_from_ContigBuilder_add(
 
 def test_override_existing_contig() -> None:
     """Asserts than an exception is raised when an override is attempted"""
-    with raises(Exception):
+    with raises(AssertionError, match="The contig contig_name already exists,"):
         builder = FastaBuilder()
         builder.add("contig_name")
         builder.add("contig_name")

--- a/fgpyo/sam/tests/test_supplementary_alignments.py
+++ b/fgpyo/sam/tests/test_supplementary_alignments.py
@@ -27,7 +27,7 @@ def test_supplementary_alignment() -> None:
     )
 
     # not enough fields
-    with pytest.raises(Exception):
+    with pytest.raises(IndexError):
         SupplementaryAlignment.parse("chr1,123,+,50S100M,60")
 
 

--- a/fgpyo/tests/test_read_structure.py
+++ b/fgpyo/tests/test_read_structure.py
@@ -97,12 +97,18 @@ def test_read_structure_variable_once_and_only_once_last_segment_ok(
     assert ReadStructure.from_string(segments=string).segments == segments
 
 
-@pytest.mark.parametrize(
-    "string",
-    ["++M", "5M++T", "5M70+T", "+M+T", "+M70T"],
-)
-def test_read_structure_variable_once_and_only_once_last_segment_exception(string: str) -> None:
-    with pytest.raises(Exception):
+@pytest.mark.parametrize("string", ["+M+T", "+M70T"])
+def test_read_structure_rejects_variable_length(string: str) -> None:
+    """Variable length should only be permitted in the last segment of the read structure."""
+    expected_msg = r"Variable length \(\+\) can only be used in the last segment"
+    with pytest.raises(AssertionError, match=expected_msg):
+        ReadStructure.from_string(segments=string)
+
+
+@pytest.mark.parametrize("string", ["++M", "5M70+T", "5M++T"])
+def test_read_structure_rejects_unknown_type(string: str) -> None:
+    """Segments with unknown type should be rejected."""
+    with pytest.raises(ValueError, match="Read structure segment had unknown type"):
         ReadStructure.from_string(segments=string)
 
 

--- a/fgpyo/tests/test_read_structure.py
+++ b/fgpyo/tests/test_read_structure.py
@@ -165,7 +165,7 @@ def test_read_structure_extract() -> None:
     assert all(r.bases == "TT" for r in extracted if r.kind == SegmentType.Skip)
 
     # too short
-    with pytest.raises(Exception):
+    with pytest.raises(AssertionError, match="Read ends before end of segment"):
         rs.extract("AAAAAAA")
 
     # last segment is truncated
@@ -196,7 +196,7 @@ def test_read_structure_extract_with_quals() -> None:
     assert all(r.quals == "44" for r in extracted if r.kind == SegmentType.Skip)
 
     # too short
-    with pytest.raises(Exception):
+    with pytest.raises(AssertionError, match="Read ends before end of segment"):
         rs.extract_with_quals("AAAAAAA", "1122334")
 
     # last segment is truncated


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/assert-raises-exception/

> ### What it does
> 
> Checks for `assertRaises` and `pytest.raises` context managers that catch `Exception` or `BaseException`.
> 
> ### Why is this bad?
> 
> These forms catch every `Exception`, which can lead to tests passing even if, e.g., the code under consideration raises a `SyntaxError` or `IndentationError`.
> 
> Either assert for a more specific exception (builtin or custom), or use `assertRaisesRegex` or `pytest.raises(..., match=<REGEX>)` respectively.