### PR TITLE
chore: fix B028 violations

### DIFF
--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -101,6 +101,7 @@ def assert_path_is_writeable(path: Path, parent_must_exist: bool = True) -> None
     warnings.warn(
         "assert_path_is_writeable is deprecated, use assert_path_is_writable instead",
         DeprecationWarning,
+        stacklevel=2,
     )
 
     assert_path_is_writable(path=path, parent_must_exist=parent_must_exist)


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/

> ### What it does
> 
> Checks for `warnings.warn` calls without an explicit `stacklevel` keyword argument.
>
> ### Why is this bad?
> 
> The `warnings.warn` method uses a `stacklevel` of 1 by default, which limits the rendered stack trace to that of the line on which the warn method is called.
> 
> It's recommended to use a `stacklevel` of 2 or higher, give the caller more context about the warning.