### PR TITLE
chore: fix B904 violations

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -224,8 +224,8 @@ class SamFileType(enum.Enum):
         ext = Path(path).suffix
         try:
             return next(iter([tpe for tpe in SamFileType if tpe.extension == ext]))
-        except StopIteration:
-            raise ValueError(f"Could not infer file type from {path}")
+        except StopIteration as ex:
+            raise ValueError(f"Could not infer file type from {path}") from ex
 
 
 def _pysam_open(

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -333,7 +333,7 @@ def _get_parser(
         nonlocal parsers
         try:
             return functools.partial(parsers[type_])
-        except KeyError:
+        except KeyError as ex:
             if (
                 type_ in [str, int, float]
                 or isinstance(type_, type)
@@ -343,13 +343,13 @@ def _get_parser(
             elif type_ == bool:
                 return functools.partial(types.parse_bool)
             elif type_ == list:
-                raise ValueError("Unable to parse list (try typing.List[type])")
+                raise ValueError("Unable to parse list (try typing.List[type])") from ex
             elif type_ == tuple:
-                raise ValueError("Unable to parse tuple (try typing.Tuple[type])")
+                raise ValueError("Unable to parse tuple (try typing.Tuple[type])") from ex
             elif type_ == set:
-                raise ValueError("Unable to parse set (try typing.Set[type])")
+                raise ValueError("Unable to parse set (try typing.Set[type])") from ex
             elif type_ == dict:
-                raise ValueError("Unable to parse dict (try typing.Mapping[type])")
+                raise ValueError("Unable to parse dict (try typing.Mapping[type])") from ex
             elif typing.get_origin(type_) == list:
                 return list_parser(cls, type_, parsers)
             elif typing.get_origin(type_) == set:
@@ -380,7 +380,7 @@ def _get_parser(
                         # typing types have no __name__.
                         getattr(type_, "__name__", repr(type_))
                     )
-                )
+                ) from ex
 
     parser = get_parser()
     # Set the name that the user expects to see in error messages (we always

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -39,12 +39,12 @@ def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
     from a string if possible"""
     try:
         return enum(value)
-    except KeyError:
+    except KeyError as ex:
         raise InspectException(
             "invalid choice: {!r} (choose from {})".format(
                 value, ", ".join(map(repr, enum.__members__))
             )
-        )
+        ) from ex
 
 
 def make_enum_parser(enum: Type[EnumType]) -> partial:


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/

> What it does
> Checks for raise statements in exception handlers that lack a from clause.
> 
> Why is this bad?
> In Python, raise can be used with or without an exception from which the current exception is derived. This is known as exception chaining. When printing the stack trace, chained exceptions are displayed in such a way so as make it easier to trace the exception back to its root cause.
> 
> When raising an exception from within an except clause, always include a from clause to facilitate exception chaining. If the exception is not chained, it will be difficult to trace the exception back to its root cause.