### PR TITLE
chore: fix B010 violations

### DIFF
--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -386,7 +386,7 @@ def _get_parser(
     # Set the name that the user expects to see in error messages (we always
     # return a temporary partial object so it's safe to set its __name__).
     # Unions and Literals don't have a __name__, but their str is fine.
-    setattr(parser, "__name__", getattr(type_, "__name__", str(type_)))
+    setattr(parser, "__name__", getattr(type_, "__name__", str(type_)))  # noqa: B010
     return parser
 
 


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/set-attr-with-constant/

> What it does
> Checks for uses of setattr that take a constant attribute value as an argument (e.g., setattr(obj, "foo", 42)).
> 
> Why is this bad?
> setattr is used to set attributes dynamically. If the attribute is defined as a constant, it is no safer than a typical property access. When possible, prefer property access over setattr calls, as the former is more concise and idiomatic.