### PR TITLE
feat: Add `find_illumina_fastq`

### DIFF
--- a/fgpyo/platform/__init__.py
+++ b/fgpyo/platform/__init__.py
@@ -1,0 +1,1 @@
+"""Platform-specific code."""

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -33,7 +33,7 @@ def find_illumina_fastq(
     Args:
         fastq_dir: The directory to search.
         sample_id: The sample ID. The function will search for a FASTQ prefixed with this string.
-        number: The read number.
+        read_number: The read number.
         recursive: If True, search subdirectories.
 
     Returns:

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -1,0 +1,65 @@
+from enum import Enum
+from enum import unique
+from glob import glob
+from pathlib import Path
+from typing import List
+
+
+@unique
+class IlluminaReadNumber(Enum):
+    """The read number of an Illumina FASTQ."""
+
+    R1 = "R1"
+    R2 = "R2"
+    I1 = "I1"
+    I2 = "I2"
+
+
+FASTQ_EXTENSIONS = [".fq", ".fastq", ".fq.gz", ".fastq.gz"]
+
+
+def find_illumina_fastq(
+    fastq_dir: Path,
+    sample_id: str,
+    read_number: IlluminaReadNumber,
+    recursive: bool = True,
+) -> Path:
+    """
+    Search a directory for a FASTQ belonging to the specified sample.
+
+    The function will search for a FASTQ prefixed with `sample_id`, including the specified
+    `read_number`, and suffixed with `.fastq`, `.fq`, `.fastq.gz`, or `.fq.gz`.
+
+    Args:
+        fastq_dir: The directory to search.
+        sample_id: The sample ID. The function will search for a FASTQ prefixed with this string.
+        number: The read number.
+        recursive: If True, search subdirectories.
+
+    Returns:
+        The path to the discovered FASTQ file.
+
+    Raises:
+        ValueError: If no FASTQ is found.
+        ValueError: If more than one FASTQ is found.
+    """
+    fastqs: List[str] = []
+    for fastq_ext in FASTQ_EXTENSIONS:
+        if recursive:
+            glob_pattern = f"{fastq_dir}/**/{sample_id}*{read_number.value}*{fastq_ext}"
+        else:
+            glob_pattern = f"{fastq_dir}/{sample_id}*{read_number.value}*{fastq_ext}"
+
+        fastqs.extend(glob(glob_pattern, recursive=recursive))
+
+    if len(fastqs) == 0:
+        raise ValueError(
+            f"No FASTQ found for sample ID '{sample_id}' and read number '{read_number.value}'"
+        )
+    if len(fastqs) > 1:
+        raise ValueError(
+            f"More than one FASTQ found for sample ID '{sample_id}' and "
+            f"read number '{read_number.value}'"
+        )
+
+    return Path(fastqs[0])

--- a/tests/fgpyo/platform/test_illumina.py
+++ b/tests/fgpyo/platform/test_illumina.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from fgpyo.platform.illumina import IlluminaReadNumber
+from fgpyo.platform.illumina import find_illumina_fastq
+
+
+@pytest.mark.parametrize("fastq_ext", [".fq", ".fastq", ".fq.gz", ".fastq.gz"])
+@pytest.mark.parametrize("read_number", IlluminaReadNumber)
+@pytest.mark.parametrize("sample_number", ["S1", "S2", None])
+@pytest.mark.parametrize("lane_number", ["L001", "L002", None])
+@pytest.mark.parametrize("last_segment", ["001", None])
+def test_find_illumina_fastq(
+    tmp_path: Path,
+    fastq_ext: str,
+    read_number: IlluminaReadNumber,
+    sample_number: Optional[str],
+    lane_number: Optional[str],
+    last_segment: Optional[str],
+) -> None:
+    """Test that we can find a FASTQ in the specified directory."""
+    fastq_dir = tmp_path
+
+    sample_name = "TestSample"
+
+    # Build FASTQ file name
+    fastq_fname = sample_name
+    if sample_number is not None:
+        fastq_fname += f"_{sample_number}"
+    if lane_number is not None:
+        fastq_fname += f"_{lane_number}"
+    fastq_fname += f"_{read_number.value}"
+    if last_segment is not None:
+        fastq_fname += f"_{last_segment}"
+    fastq_fname += fastq_ext
+
+    expected_fastq_path = fastq_dir / fastq_fname
+    expected_fastq_path.touch()
+
+    actual_fastq_path = find_illumina_fastq(
+        fastq_dir=fastq_dir, sample_id="TestSample", read_number=read_number
+    )
+
+    assert actual_fastq_path == expected_fastq_path
+
+
+def test_find_illumina_fastq_raises_if_no_fastq(tmp_path: Path) -> None:
+    """Should raise a ValueError if no FASTQ is found."""
+    with pytest.raises(ValueError, match="No FASTQ found"):
+        find_illumina_fastq(
+            fastq_dir=tmp_path, sample_id="TestSample", read_number=IlluminaReadNumber.R1
+        )
+
+
+def test_find_illumina_fastq_raises_if_multiple_fastqs(tmp_path: Path) -> None:
+    """Should raise a ValueError if multiple FASTQs are found."""
+    (tmp_path / "TestSample_R1.fq").touch()
+    (tmp_path / "TestSample_L001_R1.fq").touch()
+
+    with pytest.raises(ValueError, match="More than one FASTQ found"):
+        find_illumina_fastq(
+            fastq_dir=tmp_path, sample_id="TestSample", read_number=IlluminaReadNumber.R1
+        )
+
+
+def test_find_illumina_fastq_can_find_recursively(tmp_path: Path) -> None:
+    """Should be able to locate FASTQ files in subdirectories."""
+    expected_fastq_path = tmp_path / "subdir" / "TestSample_R1.fq.gz"
+    expected_fastq_path.parent.mkdir()
+    expected_fastq_path.touch()
+
+    actual_fastq_path = find_illumina_fastq(
+        fastq_dir=tmp_path, sample_id="TestSample", read_number=IlluminaReadNumber.R1
+    )
+
+    assert actual_fastq_path == expected_fastq_path


### PR DESCRIPTION
I'm introducing a function to search a directory for a FASTQ belonging to a given sample, regardless of extension or [name formatting](https://support.illumina.com/help/BaseSpace_Sequence_Hub_OLH_009008_2/Source/Informatics/BS/NamingConvention_FASTQ-files-swBS.htm).

I've added it to a new submodule, `util.files`, but let me know if there's a more appropriate name or you would like to see it added to an existing module