### PR TITLE
feat: add len, iter, and getitem dunder methods to Cigar

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -531,6 +531,15 @@ class Cigar:
         else:
             return "*"
 
+    def __len__(self) -> int:
+        return len(self.elements)
+
+    def __iter__(self) -> Iterator[CigarElement]:
+        return iter(self.elements)
+
+    def __getitem__(self, index: int) -> CigarElement:
+        return self.elements[index]
+
     def reversed(self) -> "Cigar":
         """Returns a copy of the Cigar with the elements in reverse order."""
         return Cigar(tuple(reversed(self.elements)))

--- a/fgpyo/sam/tests/test_sam.py
+++ b/fgpyo/sam/tests/test_sam.py
@@ -372,3 +372,25 @@ def test_calc_edit_info_with_aligned_Ns() -> None:
     assert info.deletions == 0
     assert info.deleted_bases == 0
     assert info.nm == 5
+
+
+@pytest.mark.parametrize("cigarstring", ["10M5I4M", "10M5D4M", "10M40S", "*"])
+def test_cigar_length(cigarstring: str) -> None:
+    """CIGAR length should be the number of elements."""
+    cigar = Cigar.from_cigarstring(cigarstring)
+    assert len(cigar) == len(cigar.elements)
+
+
+@pytest.mark.parametrize("cigarstring", ["10M5I4M", "10M5D4M", "10M40S", "*"])
+def test_cigar_get_item(cigarstring: str) -> None:
+    """CIGAR elements should be accessible by index."""
+    cigar = Cigar.from_cigarstring(cigarstring)
+    for i in range(len(cigar)):
+        assert cigar[i] == cigar.elements[i]
+
+
+@pytest.mark.parametrize("cigarstring", ["10M5I4M", "10M5D4M", "10M40S", "*"])
+def test_cigar_iterable(cigarstring: str) -> None:
+    """Iterating over a CIGAR should yield its elements."""
+    cigar = Cigar.from_cigarstring(cigarstring)
+    assert [e for e in cigar] == list(cigar.elements)


### PR DESCRIPTION
Per [Yossi's suggestion in Slack yesterday](https://fulcrumgenomics.slack.com/archives/C04BQ9RMJ2G/p1719424987601389?thread_ts=1719352429.511779&cid=C04BQ9RMJ2G), I believe this will make `Cigar` more ergonomic