### PR TITLE
Feat: add longest_hp_len() to fgpyo/sequence.py

### DIFF
--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -70,3 +70,21 @@ def reverse_complement(bases: str) -> str:
         the reverse complement of the provided base string
     """
     return "".join([_COMPLEMENTS[b] for b in bases[::-1]])
+
+
+def longest_hp_length(bases: str) -> int:
+    """Calculates the length of the longest homopolymer in the input sequence."""
+    max_hp = 0
+    for i in range(0, len(bases)):
+        base = bases[i]
+        hp = 0
+
+        for j in range(i, len(bases)):
+            if bases[j] == base:
+                hp += 1
+            else:
+                break
+
+        max_hp = max(max_hp, hp)
+
+    return max_hp

--- a/fgpyo/tests/test_sequence.py
+++ b/fgpyo/tests/test_sequence.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from fgpyo.sequence import longest_hp_length
 from fgpyo.sequence import reverse_complement
 
 
@@ -15,3 +16,12 @@ def test_reverse_complement() -> None:
 
     with pytest.raises(KeyError):
         reverse_complement("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+
+def test_homopolymer() -> None:
+    assert longest_hp_length("") == 0
+    assert longest_hp_length("A") == 1
+    assert longest_hp_length("AAAA") == 4
+    assert longest_hp_length("ACTACGATTTTTACGAT") == 5
+    assert longest_hp_length("ACTACGATTTTTACGAT") == 5
+    assert longest_hp_length("TTTTACTACGAACGAGTTTTT") == 5

--- a/fgpyo/tests/test_sequence.py
+++ b/fgpyo/tests/test_sequence.py
@@ -18,10 +18,16 @@ def test_reverse_complement() -> None:
         reverse_complement("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 
-def test_homopolymer() -> None:
-    assert longest_hp_length("") == 0
-    assert longest_hp_length("A") == 1
-    assert longest_hp_length("AAAA") == 4
-    assert longest_hp_length("ACTACGATTTTTACGAT") == 5
-    assert longest_hp_length("ACTACGATTTTTACGAT") == 5
-    assert longest_hp_length("TTTTACTACGAACGAGTTTTT") == 5
+@pytest.mark.parametrize(
+    "bases, expected_hp_len",
+    [
+        ("", 0),
+        ("A", 1),
+        ("AAAA", 4),
+        ("ACTACGATTTTTACGAT", 5),
+        ("ACTACGATTTTTACGAT", 5),
+        ("TTTTACTACGAACGAGTTTTT", 5),
+    ],
+)
+def test_homopolymer(bases: str, expected_hp_len: int) -> None:
+    assert longest_hp_length(bases) == expected_hp_len


### PR DESCRIPTION
Add method to calculate the length of the longest homopolymer in a string of bases. Corresponding unit tests also added.
