### PR TITLE
doc: Add installation of `mkdocs` dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ A simple way to create an environment with the desired version of python and poe
 ```bash
 conda create -n fgpyo -c conda-forge "python>=3.8" poetry
 conda activate fgpyo
-poetry install
+
+# --all-extras is required to install `mkdocs` and associated dependencies,
+# which are required for development 
+poetry install --all-extras
 ```
 
 [rtd-link]:    http://fgpyo.readthedocs.org/en/stable


### PR DESCRIPTION
This documentation is intended to clarify a couple points of confusion I encountered when adding #163 

1. `mkdocs` and its dependencies are declared as extras rather than as a dependency group - I'm sufficiently novice to `poetry` that I didn't know how to install these, and I thought including the required flag in the README would be helpful for other folks coming in who want to contribute.

2. Since `ci/check.sh` runs `mkdocs`, these dependencies aren't _really_ optional, and so our installation instructions should include them by default.

I opened #165 to discuss possibly reorganizing, but I'd like to get this PR in as-is so the docs are up-to-date.