### PR TITLE
ci: remove the use of github-actions-ci environment

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   testing:
     runs-on: ubuntu-latest
-    environment: github-actions-ci
     strategy:
       matrix:
         PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
We are now using a organizational-level token