### PR TITLE
feat: overloaded 'SeqDict.from_sam()' method to support SAM files (#176)

### DIFF
--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -449,19 +449,19 @@ class SequenceDictionary(Mapping[Union[str, int], SequenceMetadata]):
 
     @staticmethod
     @overload
-    def from_sam(data: Path) -> "SequenceDictionary": ...  # pragma: no cover
+    def from_sam(data: Path) -> "SequenceDictionary": ...
 
     @staticmethod
     @overload
-    def from_sam(data: pysam.AlignmentFile) -> "SequenceDictionary": ...  # pragma: no cover
+    def from_sam(data: pysam.AlignmentFile) -> "SequenceDictionary": ...
 
     @staticmethod
     @overload
-    def from_sam(data: pysam.AlignmentHeader) -> "SequenceDictionary": ...  # pragma: no cover
+    def from_sam(data: pysam.AlignmentHeader) -> "SequenceDictionary": ...
 
     @staticmethod
     @overload
-    def from_sam(data: List[Dict[str, Any]]) -> "SequenceDictionary": ...  # pragma: no cover
+    def from_sam(data: List[Dict[str, Any]]) -> "SequenceDictionary": ...
 
     @staticmethod
     def from_sam(

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -467,8 +467,17 @@ class SequenceDictionary(Mapping[Union[str, int], SequenceMetadata]):
     def from_sam(
         data: Union[Path, pysam.AlignmentFile, pysam.AlignmentHeader, List[Dict[str, Any]]],
     ) -> "SequenceDictionary":
-        """Creates a `SequenceDictionary` from either a `pysam.AlignmentHeader` or from
-        the list of sequences returned by `pysam.AlignmentHeader.to_dict()["SQ"]`."""
+        """Creates a `SequenceDictionary` from a SAM file or its header.
+
+        Args:
+            data: The input may be any of:
+                - a path to a SAM file
+                - an open `pysam.AlignmentFile`
+                - the `pysam.AlignmentHeader` associated with a `pysam.AlignmentFile`
+                - the contents of a header's `SQ` fields, as returned by `AlignmentHeader.to_dict()`
+        Returns:
+            A `SequenceDictionary` mapping refrence names to their metadata.
+        """
         if isinstance(data, pysam.AlignmentHeader):
             return SequenceDictionary.from_sam(data.to_dict()["SQ"])
         if isinstance(data, pysam.AlignmentFile):

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -498,13 +498,6 @@ class SequenceDictionary(Mapping[Union[str, int], SequenceMetadata]):
 
         return seq_dict
 
-    # TODO: mypy doesn't like these
-    # @overload
-    # def __getitem__(self, key: str) -> SequenceMetadata: ...
-    #
-    # @overload
-    # def __getitem__(self, index: int) -> SequenceMetadata: ...
-
     def __getitem__(self, key: Union[str, int]) -> SequenceMetadata:
         return self._dict[key] if isinstance(key, str) else self.infos[key]
 

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -449,19 +449,19 @@ class SequenceDictionary(Mapping[Union[str, int], SequenceMetadata]):
 
     @staticmethod
     @overload
-    def from_sam(data: Path) -> "SequenceDictionary": ...
+    def from_sam(data: Path) -> "SequenceDictionary": ...  # pragma: no cover
 
     @staticmethod
     @overload
-    def from_sam(data: pysam.AlignmentFile) -> "SequenceDictionary": ...
+    def from_sam(data: pysam.AlignmentFile) -> "SequenceDictionary": ...  # pragma: no cover
 
     @staticmethod
     @overload
-    def from_sam(data: pysam.AlignmentHeader) -> "SequenceDictionary": ...
+    def from_sam(data: pysam.AlignmentHeader) -> "SequenceDictionary": ...  # pragma: no cover
 
     @staticmethod
     @overload
-    def from_sam(data: List[Dict[str, Any]]) -> "SequenceDictionary": ...
+    def from_sam(data: List[Dict[str, Any]]) -> "SequenceDictionary": ...  # pragma: no cover
 
     @staticmethod
     def from_sam(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,8 @@ warn_unused_configs         = true
 warn_unused_ignores         = true
 enable_error_code           = "ignore-without-code"
 exclude                     = ["site/", "docs/"]
+
+[tool.coverage.report]
+exclude_lines =
+    pragma: not covered
+    @overload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ enable_error_code           = "ignore-without-code"
 exclude                     = ["site/", "docs/"]
 
 [tool.coverage.report]
-exclude_lines =
-    pragma: not covered
-    @overload
+exclude_lines = [
+    "pragma: not covered",
+    "@overload"
+]

--- a/tests/fgpyo/fasta/data/sequence.dict
+++ b/tests/fgpyo/fasta/data/sequence.dict
@@ -1,0 +1,4 @@
+@HD	VN:1.5
+@SQ	SN:chr1	LN:10
+@SQ	SN:chr2	LN:20	AN:chr3
+@RG	ID:foo

--- a/tests/fgpyo/fasta/data/sequence.dict
+++ b/tests/fgpyo/fasta/data/sequence.dict
@@ -1,4 +1,0 @@
-@HD	VN:1.5
-@SQ	SN:chr1	LN:10
-@SQ	SN:chr2	LN:20	AN:chr3
-@RG	ID:foo

--- a/tests/fgpyo/fasta/test_sequence_dictionary.py
+++ b/tests/fgpyo/fasta/test_sequence_dictionary.py
@@ -339,6 +339,8 @@ def test_sequence_dictionary_to_and_from_sam() -> None:
     assert SequenceDictionary.from_sam(mapping) == sd
     assert SequenceDictionary.from_sam(header) == sd
     assert sd.to_sam_header(extra_header={"RG": [{"ID": "foo"}]})
+    with pytest.raises(ValueError):
+        SequenceDictionary.from_sam([{}])
 
 
 def test_sequence_dictionary_mapping() -> None:

--- a/tests/fgpyo/fasta/test_sequence_dictionary.py
+++ b/tests/fgpyo/fasta/test_sequence_dictionary.py
@@ -333,9 +333,9 @@ def test_sequence_dictionary_to_and_from_sam() -> None:
         header_dict={"HD": {"VN": "1.5"}, "SQ": mapping, "RG": [{"ID": "foo"}]}
     )
     samfile: Path = builder.SamBuilder(sd=mapping).to_path()
-    alignment: pysam.AlignmentFile = reader(samfile)
+    with reader(samfile) as alignment_fh:  # pysam.AlignmentFile
+        assert SequenceDictionary.from_sam(alignment_fh) == sd
     assert SequenceDictionary.from_sam(samfile) == sd
-    assert SequenceDictionary.from_sam(alignment) == sd
     assert SequenceDictionary.from_sam(mapping) == sd
     assert SequenceDictionary.from_sam(header) == sd
     assert sd.to_sam_header(extra_header={"RG": [{"ID": "foo"}]})

--- a/tests/fgpyo/fasta/test_sequence_dictionary.py
+++ b/tests/fgpyo/fasta/test_sequence_dictionary.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
@@ -11,6 +12,8 @@ from fgpyo.fasta.sequence_dictionary import Keys
 from fgpyo.fasta.sequence_dictionary import SequenceDictionary
 from fgpyo.fasta.sequence_dictionary import SequenceMetadata
 from fgpyo.fasta.sequence_dictionary import Topology
+from fgpyo.sam import SamFileType
+from fgpyo.sam import reader
 
 
 def test_alternate_locus_raises_start_gt_end() -> None:
@@ -315,10 +318,6 @@ def test_sequence_dictionary_same_as() -> None:
     assert not this.same_as(that)
 
 
-# to_sam
-# from_sam
-
-
 def test_sequence_dictionary_to_and_from_sam() -> None:
     sd = SequenceDictionary(
         infos=[
@@ -333,7 +332,10 @@ def test_sequence_dictionary_to_and_from_sam() -> None:
     header = pysam.AlignmentHeader.from_dict(
         header_dict={"HD": {"VN": "1.5"}, "SQ": mapping, "RG": [{"ID": "foo"}]}
     )
-
+    samfile = Path(__file__).parent / "data" / "sequence.dict"
+    alignment: pysam.AlignmentFile = reader(samfile, file_type=SamFileType.SAM)
+    assert SequenceDictionary.from_sam(samfile) == sd
+    assert SequenceDictionary.from_sam(alignment) == sd
     assert SequenceDictionary.from_sam(mapping) == sd
     assert SequenceDictionary.from_sam(header) == sd
     assert sd.to_sam_header(extra_header={"RG": [{"ID": "foo"}]})

--- a/tests/fgpyo/fasta/test_sequence_dictionary.py
+++ b/tests/fgpyo/fasta/test_sequence_dictionary.py
@@ -12,7 +12,7 @@ from fgpyo.fasta.sequence_dictionary import Keys
 from fgpyo.fasta.sequence_dictionary import SequenceDictionary
 from fgpyo.fasta.sequence_dictionary import SequenceMetadata
 from fgpyo.fasta.sequence_dictionary import Topology
-from fgpyo.sam import SamFileType
+from fgpyo.sam import builder
 from fgpyo.sam import reader
 
 
@@ -332,8 +332,8 @@ def test_sequence_dictionary_to_and_from_sam() -> None:
     header = pysam.AlignmentHeader.from_dict(
         header_dict={"HD": {"VN": "1.5"}, "SQ": mapping, "RG": [{"ID": "foo"}]}
     )
-    samfile = Path(__file__).parent / "data" / "sequence.dict"
-    alignment: pysam.AlignmentFile = reader(samfile, file_type=SamFileType.SAM)
+    samfile: Path = builder.SamBuilder(sd=mapping).to_path()
+    alignment: pysam.AlignmentFile = reader(samfile)
     assert SequenceDictionary.from_sam(samfile) == sd
     assert SequenceDictionary.from_sam(alignment) == sd
     assert SequenceDictionary.from_sam(mapping) == sd


### PR DESCRIPTION
 - in addition to pysam SAM headers and SAM header dicts, SeqDicts can now be initialized from SAM file paths and pysam SAM files
 - added basic tests for this new functionality