### PR TITLE
feat: add cigar utility method get_alignment_offsets 

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -548,10 +548,9 @@ class Cigar:
         return sum([elem.length_on_target for elem in self.elements])
 
     def get_query_alignment_offsets(self, reverse: bool = False) -> Optional[range]:
-        """
-        Get the 0-based, end-exclusive positions of the first and last aligned base in the query.
-        The resulting range will contain the range of positions in the SEQ string for the bases t
-        hat are aligned. If no bases are aligned, the return value will be None.
+        """Gets the 0-based, end-exclusive positions of the first and last aligned base in the query.
+        The resulting range will contain the range of positions in the SEQ string for the bases
+        that are aligned. If no bases are aligned, the return value will be None.
 
         Args:
             reverse: If True, count from the end of the query. i.e. find the offsets
@@ -560,12 +559,11 @@ class Cigar:
 
         Returns:
             A range, defining the start and stop offsets of the aligned part
-            of the query. These offsets are 0-based and open-ended, with respect to the
-            beginning of the query. (If 'reverse' is True, the offsets are with
-            respect to the reversed query.)
-            If no bases are aligned, the return value will be None.
+                of the query. These offsets are 0-based and open-ended, with respect to the
+                beginning of the query. (If 'reverse' is True, the offsets are with
+                respect to the reversed query.)
+                If no bases are aligned, the return value will be None.
         """
-        # breaking the build
         start_offset: int = 0
         end_offset: int = 0
         element: CigarElement

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -547,22 +547,22 @@ class Cigar:
         """Returns the length of the alignment on the target sequence."""
         return sum([elem.length_on_target for elem in self.elements])
 
-    def query_alignment_offsets(self) -> tuple:
+    def query_alignment_offsets(self) -> Tuple[int, int]:
         """Gets the 0-based, end-exclusive positions of the first and last aligned base in the
         query.
 
         The resulting range will contain the range of positions in the SEQ string for
-        the bases that are aligned. If no bases are aligned, the return value will be None.
+        the bases that are aligned.
         If counting from the end of the query is desired, use
         `cigar.reversed().query_alignment_offsets()`
 
         Returns:
             A tuple (start, stop) containing the start and stop positions
                 of the aligned part of the query. These offsets are 0-based and open-ended, with
-                respect to the beginning of the query. If no bases are aligned.
+                respect to the beginning of the query.
 
-        Throws:
-            A ValueError exception if according to the cigar, there are no aligned query bases.
+        Raises:
+            ValueError: If according to the cigar, there are no aligned query bases.
         """
         start_offset: int = 0
         end_offset: int = 0

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -548,9 +548,9 @@ class Cigar:
         return sum([elem.length_on_target for elem in self.elements])
 
     def query_alignment_offsets(self, reverse: bool = False) -> Optional[range]:
-        """Gets the 0-based, end-exclusive positions of the first and last aligned base in the query.
-        The resulting range will contain the range of positions in the SEQ string for the bases
-        that are aligned. If no bases are aligned, the return value will be None.
+        """Gets the 0-based, end-exclusive positions of the first and last aligned base in the
+        query. The resulting range will contain the range of positions in the SEQ string for
+        the bases that are aligned. If no bases are aligned, the return value will be None.
 
         Args:
             reverse: If True, count from the end of the query. i.e. find the offsets

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -549,15 +549,16 @@ class Cigar:
 
     def get_alignment_offsets(self, reverse: bool = False) -> Tuple[int, int]:
         """
-                Get the starting and ending offset for the alignment based on the CIGAR string.
+        Get the starting and ending offsets for the alignment based on the CIGAR string.
 
-                Args:
-                    reverse: Whether to count from the end of the read sequence.
-                        Default is False, which counts from the beginning of the read sequence.
+        Args:
+            reverse: If True, count from the end of the read sequence.
+                Otherwise (default behavior), count from the beginning of the read sequence.
 
-                Returns: Tuple[int, int] The start and end of the _aligned part_ of the read.
-                    0-based, open-ended offsets (to the read sequence.)
-                    If 'reverse' is True, the offsets count from the end of the read sequence.
+        Returns: 
+            A tuple (start, end), defining the start and end offsets of the _aligned part_ of the read.
+            These offsets are 0-based and open-ended, with respect to the beginning of the read sequence.
+            (If 'reverse' is True, the offsets are with respect to the end of the read sequence.)
 
         # TODO: FIGURE OUT WHY the following three lines causes mkdocs to fail
         # If the Cigar contains no alignment operators that consume sequence bases, or
@@ -571,11 +572,14 @@ class Cigar:
         elements = self.elements if not reverse else reversed(self.elements)
         for cig_el in elements:
             if cig_el.operator.is_clipping and not alignment_began:
+                # We are in the clipping operators preceding the alignment
                 start_offset += cig_el.length_on_query
                 end_offset += cig_el.length_on_query
             elif cig_el.operator.is_clipping:
+                # We have exited the alignment and are in the clipping operators after the alignment
                 break
             else:
+                # We are within the alignment
                 alignment_began = True
                 end_offset += cig_el.length_on_query
 

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -547,7 +547,7 @@ class Cigar:
         """Returns the length of the alignment on the target sequence."""
         return sum([elem.length_on_target for elem in self.elements])
 
-    def get_query_alignment_offsets(self, reverse: bool = False) -> Optional[range]:
+    def query_alignment_offsets(self, reverse: bool = False) -> Optional[range]:
         """Gets the 0-based, end-exclusive positions of the first and last aligned base in the query.
         The resulting range will contain the range of positions in the SEQ string for the bases
         that are aligned. If no bases are aligned, the return value will be None.

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -158,6 +158,7 @@ and slices):
 import enum
 import io
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import IO
 from typing import Any
@@ -360,6 +361,46 @@ class _CigarOpUtil:
     }
 
 
+@dataclass(frozen=True)
+class RangeOfBases:
+    """A simple data class for holding offsets into a range of bases in a read.
+
+    Attributes:
+        start (int): The starting offset (0-based) into the range.
+        stop (int): The ending (excluded) offset into the range.
+
+    Properties:
+        slice: A slice of the range. can be used rto extract the aligned bases from a string.
+        range: The range of bases represented by this object. Can be used to obtain the indexes
+            into the aligned bases in the read.
+        __len__: The length of the range.
+        __iter__: Enables unpacking of start and stop into a tuple by return the iterator of
+            (start, stop)
+
+    """
+
+    start: int
+    stop: int
+
+    @property
+    def slice(self) -> slice:
+        """A slice of the range"""
+        return slice(self.start, self.stop)
+
+    @property
+    def range(self) -> range:
+        """The range of bases represented by this object"""
+        return range(self.start, self.stop)
+
+    def __len__(self) -> int:
+        """The length of the range"""
+        return self.stop - self.start
+
+    def __iter__(self):
+        """enables unpacking of start and stop into a tuple"""
+        return (self.start, self.stop).__iter__()
+
+
 @enum.unique
 class CigarOp(enum.Enum):
     """Enumeration of operators that can appear in a Cigar string.
@@ -547,7 +588,7 @@ class Cigar:
         """Returns the length of the alignment on the target sequence."""
         return sum([elem.length_on_target for elem in self.elements])
 
-    def query_alignment_offsets(self, reverse: bool = False) -> Optional[range]:
+    def query_alignment_offsets(self, reverse: bool = False) -> Optional[RangeOfBases]:
         """Gets the 0-based, end-exclusive positions of the first and last aligned base in the
         query. The resulting range will contain the range of positions in the SEQ string for
         the bases that are aligned. If no bases are aligned, the return value will be None.
@@ -556,13 +597,12 @@ class Cigar:
             reverse: If True, count from the end of the query. i.e. find the offsets
                 using the reversed elements of the cigar.
 
-
         Returns:
-            A range, defining the start and stop offsets of the aligned part
-                of the query. These offsets are 0-based and open-ended, with respect to the
-                beginning of the query. (If 'reverse' is True, the offsets are with
-                respect to the reversed query.)
-                If no bases are aligned, the return value will be None.
+            A RangeOfBases object containing the start and stop positions (0-based, end-exclusive)
+                of the aligned part of the query. These offsets are 0-based and open-ended, with
+                respect to the beginning of the query. (If 'reverse' is True, the offsets are with
+                respect to the reversed query.) If no bases are aligned, the return value will be
+                None.
         """
         start_offset: int = 0
         end_offset: int = 0
@@ -583,7 +623,7 @@ class Cigar:
                 # We have exited the alignment and are in the clipping operators after the alignment
                 break
 
-        ret = range(start_offset, end_offset)
+        ret = RangeOfBases(start_offset, end_offset)
         if not alignment_began or len(ret) == 0:
             return None
         return ret

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -548,8 +548,8 @@ class Cigar:
         return sum([elem.length_on_target for elem in self.elements])
 
     def query_alignment_offsets(self) -> Tuple[int, int]:
-        """Gets the 0-based, end-exclusive positions of the first and last aligned base in the
-        query.
+        """
+        Gets the 0-based, end-exclusive positions of the first and last aligned base in the query.
 
         The resulting range will contain the range of positions in the SEQ string for
         the bases that are aligned.
@@ -583,7 +583,7 @@ class Cigar:
                 break
 
         if start_offset == end_offset:
-            raise ValueError(f"Cigar {self.__str__()} has no aligned bases")
+            raise ValueError(f"Cigar {self} has no aligned bases")
         return start_offset, end_offset
 
     def __getitem__(

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -582,10 +582,9 @@ class Cigar:
                 # We have exited the alignment and are in the clipping operators after the alignment
                 break
 
-        ret = (start_offset, end_offset)
         if start_offset == end_offset:
             raise ValueError(f"Cigar {self.__str__()} has no aligned bases")
-        return ret
+        return start_offset, end_offset
 
     def __getitem__(
         self, index: Union[int, slice]

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -562,7 +562,7 @@ class Cigar:
                 respect to the beginning of the query. If no bases are aligned.
 
         Throws:
-            An
+            A ValueError exception if according to the cigar, there are no aligned query bases.
         """
         start_offset: int = 0
         end_offset: int = 0
@@ -584,7 +584,7 @@ class Cigar:
 
         ret = (start_offset, end_offset)
         if start_offset == end_offset:
-            raise ValueError("Cigar has no aligned bases")
+            raise ValueError(f"Cigar {self.__str__()} has no aligned bases")
         return ret
 
     def __getitem__(

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -396,7 +396,7 @@ class RangeOfBases:
         """The length of the range"""
         return self.stop - self.start
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable[int]:
         """enables unpacking of start and stop into a tuple"""
         return (self.start, self.stop).__iter__()
 

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -31,3 +31,51 @@ def test_bad_index_raises_index_error(index: int) -> None:
 def test_bad_index_raises_type_error(index: int) -> None:
     with pytest.raises(TypeError):
         cigar[index]
+
+
+@pytest.mark.parametrize(
+    ("cigar_string", "start", "end"),
+    {
+        ("10M", 0, 10),
+        ("10M10I", 0, 20),
+        ("10X10I", 0, 20),
+        ("10X10D", 0, 10),
+        ("10=10D", 0, 10),
+        ("10S10M", 10, 20),
+        ("10H10M", 0, 10),
+        ("10H10S10M", 10, 20),
+        ("10H10S10M5S", 10, 20),
+        ("10H10S10M5S10H", 10, 20),
+        ("10H", 0, 0),
+        ("10S", 10, 10),
+        ("10S10H", 10, 10),
+        ("5H10S10H", 10, 10),
+    },
+)
+def test_get_alignments(cigar_string: str, start: int, end: int) -> None:
+    cig = Cigar.from_cigarstring(cigar_string)
+    assert Cigar.get_alignment_offsets(cig, False) == (start, end)
+
+
+@pytest.mark.parametrize(
+    ("cigar_string", "start", "end"),
+    {
+        ("10M", 0, 10),
+        ("10M10I", 0, 20),
+        ("10X10I", 0, 20),
+        ("10X10D", 0, 10),
+        ("10=10D", 0, 10),
+        ("10S10M", 0, 10),
+        ("10H10M", 0, 10),
+        ("10H10S10M", 0, 10),
+        ("10H10S10M5S", 5, 15),
+        ("10H10S10M5S10H", 5, 15),
+        ("10H", 0, 0),
+        ("10S", 10, 10),
+        ("10S10H", 10, 10),
+        ("5H10S10H", 10, 10),
+    },
+)
+def test_get_alignments_reversed(cigar_string: str, start: int, end: int) -> None:
+    cig = Cigar.from_cigarstring(cigar_string)
+    assert Cigar.get_alignment_offsets(cig, True) == (start, end)

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -4,7 +4,6 @@ from typing import Tuple
 import pytest
 
 from fgpyo.sam import Cigar
-from fgpyo.sam import RangeOfBases
 
 cigar = Cigar.from_cigarstring("1M4D45N37X23I11=")
 
@@ -40,54 +39,61 @@ def test_bad_index_raises_type_error(index: int) -> None:
 @pytest.mark.parametrize(
     ("cigar_string", "maybe_range"),
     {
-        ("10M", RangeOfBases(0, 10)),
-        ("10M10I", RangeOfBases(0, 20)),
-        ("10X10I", RangeOfBases(0, 20)),
-        ("10X10D", RangeOfBases(0, 10)),
-        ("10=10D", RangeOfBases(0, 10)),
-        ("10S10M", RangeOfBases(10, 20)),
-        ("10H10M", RangeOfBases(0, 10)),
-        ("10H10S10M", RangeOfBases(10, 20)),
-        ("10H10S10M5S", RangeOfBases(10, 20)),
-        ("10H10S10M5S10H", RangeOfBases(10, 20)),
+        ("10M", (0, 10)),
+        ("10M10I", (0, 20)),
+        ("10X10I", (0, 20)),
+        ("10X10D", (0, 10)),
+        ("10=10D", (0, 10)),
+        ("10S10M", (10, 20)),
+        ("10H10M", (0, 10)),
+        ("10H10S10M", (10, 20)),
+        ("10H10S10M5S", (10, 20)),
+        ("10H10S10M5S10H", (10, 20)),
         ("10H", None),
         ("10S", None),
         ("10S10H", None),
         ("5H10S10H", None),
         ("76D", None),
-        ("76I", RangeOfBases(0, 76)),
+        ("76I", (0, 76)),
         ("10P76S", None),
         ("50S1000N50S", None),
     },
 )
-def test_get_alignments(cigar_string: str, maybe_range: Optional[RangeOfBases]) -> None:
+def test_get_alignments(cigar_string: str, maybe_range: Optional[tuple]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-
-    assert Cigar.query_alignment_offsets(cig, reverse=False) == maybe_range
+    if not maybe_range:
+        with pytest.raises(ValueError):
+            cig.query_alignment_offsets()
+    else:
+        ret = cig.query_alignment_offsets()
+        assert ret == maybe_range
 
 
 @pytest.mark.parametrize(
     ("cigar_string", "maybe_range"),
     {
-        ("10M", RangeOfBases(0, 10)),
-        ("10M10I", RangeOfBases(0, 20)),
-        ("10X10I", RangeOfBases(0, 20)),
-        ("10X10D", RangeOfBases(0, 10)),
-        ("10=10D", RangeOfBases(0, 10)),
-        ("10S10M", RangeOfBases(0, 10)),
-        ("10H10M", RangeOfBases(0, 10)),
-        ("10H10S10M", RangeOfBases(0, 10)),
-        ("10H10S10M5S", RangeOfBases(5, 15)),
-        ("10H10S10M5S10H", RangeOfBases(5, 15)),
+        ("10M", (0, 10)),
+        ("10M10I", (0, 20)),
+        ("10X10I", (0, 20)),
+        ("10X10D", (0, 10)),
+        ("10=10D", (0, 10)),
+        ("10S10M", (0, 10)),
+        ("10H10M", (0, 10)),
+        ("10H10S10M", (0, 10)),
+        ("10H10S10M5S", (5, 15)),
+        ("10H10S10M5S10H", (5, 15)),
         ("10H", None),
         ("10S", None),
         ("10S10H", None),
         ("5H10S10H", None),
     },
 )
-def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[Tuple[int, int]]) -> None:
+def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[Tuple]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
 
-    assert Cigar.query_alignment_offsets(cig, reverse=True) == maybe_range
-    if maybe_range is not None:
-        start, stop = maybe_range
+    if not maybe_range:
+        with pytest.raises(ValueError):
+            cig.reversed().query_alignment_offsets()
+    else:
+        ret = cig.reversed().query_alignment_offsets()
+        assert ret == maybe_range

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 from fgpyo.sam import Cigar
@@ -34,48 +36,52 @@ def test_bad_index_raises_type_error(index: int) -> None:
 
 
 @pytest.mark.parametrize(
-    ("cigar_string", "start", "end"),
+    ("cigar_string", "maybe_range"),
     {
-        ("10M", 0, 10),
-        ("10M10I", 0, 20),
-        ("10X10I", 0, 20),
-        ("10X10D", 0, 10),
-        ("10=10D", 0, 10),
-        ("10S10M", 10, 20),
-        ("10H10M", 0, 10),
-        ("10H10S10M", 10, 20),
-        ("10H10S10M5S", 10, 20),
-        ("10H10S10M5S10H", 10, 20),
-        ("10H", 0, 0),
-        ("10S", 10, 10),
-        ("10S10H", 10, 10),
-        ("5H10S10H", 10, 10),
+        ("10M", range(0, 10)),
+        ("10M10I", range(0, 20)),
+        ("10X10I", range(0, 20)),
+        ("10X10D", range(0, 10)),
+        ("10=10D", range(0, 10)),
+        ("10S10M", range(10, 20)),
+        ("10H10M", range(0, 10)),
+        ("10H10S10M", range(10, 20)),
+        ("10H10S10M5S", range(10, 20)),
+        ("10H10S10M5S10H", range(10, 20)),
+        ("10H", None),
+        ("10S", None),
+        ("10S10H", None),
+        ("5H10S10H", None),
+        ("76D", None),
+        ("76I", range(0, 76)),
+        ("10P76S", None),
+        ("50S1000N50S", None),
     },
 )
-def test_get_alignments(cigar_string: str, start: int, end: int) -> None:
+def test_get_alignments(cigar_string: str, maybe_range: Optional[range]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-    assert Cigar.get_alignment_offsets(cig, reverse=False) == (start, end)
+    assert Cigar.get_query_alignment_offsets(cig, reverse=False) == maybe_range
 
 
 @pytest.mark.parametrize(
-    ("cigar_string", "start", "end"),
+    ("cigar_string", "maybe_range"),
     {
-        ("10M", 0, 10),
-        ("10M10I", 0, 20),
-        ("10X10I", 0, 20),
-        ("10X10D", 0, 10),
-        ("10=10D", 0, 10),
-        ("10S10M", 0, 10),
-        ("10H10M", 0, 10),
-        ("10H10S10M", 0, 10),
-        ("10H10S10M5S", 5, 15),
-        ("10H10S10M5S10H", 5, 15),
-        ("10H", 0, 0),
-        ("10S", 10, 10),
-        ("10S10H", 10, 10),
-        ("5H10S10H", 10, 10),
+        ("10M", range(0, 10)),
+        ("10M10I", range(0, 20)),
+        ("10X10I", range(0, 20)),
+        ("10X10D", range(0, 10)),
+        ("10=10D", range(0, 10)),
+        ("10S10M", range(0, 10)),
+        ("10H10M", range(0, 10)),
+        ("10H10S10M", range(0, 10)),
+        ("10H10S10M5S", range(5, 15)),
+        ("10H10S10M5S10H", range(5, 15)),
+        ("10H", None),
+        ("10S", None),
+        ("10S10H", None),
+        ("5H10S10H", None),
     },
 )
-def test_get_alignments_reversed(cigar_string: str, start: int, end: int) -> None:
+def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[range]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-    assert Cigar.get_alignment_offsets(cig, reverse=True) == (start, end)
+    assert Cigar.get_query_alignment_offsets(cig, reverse=True) == maybe_range

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -52,6 +52,9 @@ def test_bad_index_raises_type_error(index: int) -> None:
     ],
 )
 def test_query_alignment_offsets(cigar_string: str, expected_range: Tuple[int, int]) -> None:
+    """
+    cig.query_alignment_offsets() should return the expected results.
+    """
     cig = Cigar.from_cigarstring(cigar_string)
     ret = cig.query_alignment_offsets()
     assert ret == expected_range
@@ -70,6 +73,7 @@ def test_query_alignment_offsets(cigar_string: str, expected_range: Tuple[int, i
     ],
 )
 def test_query_alignment_offsets_failures(cigar_string: str) -> None:
+    """query_alignment_offsets() should raise a ValueError if the CIGAR has no aligned positions."""
     cig = Cigar.from_cigarstring(cigar_string)
     with pytest.raises(ValueError):
         cig.query_alignment_offsets()
@@ -96,6 +100,10 @@ def test_query_alignment_offsets_failures(cigar_string: str) -> None:
 def test_query_alignment_offsets_reversed(
     cigar_string: str, expected_range: Tuple[int, int]
 ) -> None:
+    """
+    cig.revered().query_alignment_offsets() should return the expected results.
+    """
+
     cig = Cigar.from_cigarstring(cigar_string)
 
     ret = cig.reversed().query_alignment_offsets()

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -78,4 +78,4 @@ def test_get_alignments(cigar_string: str, start: int, end: int) -> None:
 )
 def test_get_alignments_reversed(cigar_string: str, start: int, end: int) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-    assert Cigar.get_alignment_offsets(cig, True) == (start, end)
+    assert Cigar.get_alignment_offsets(cig, reverse=True) == (start, end)

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -60,7 +60,7 @@ def test_bad_index_raises_type_error(index: int) -> None:
 )
 def test_get_alignments(cigar_string: str, maybe_range: Optional[range]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-    assert Cigar.get_query_alignment_offsets(cig, reverse=False) == maybe_range
+    assert Cigar.query_alignment_offsets(cig, reverse=False) == maybe_range
 
 
 @pytest.mark.parametrize(
@@ -84,4 +84,4 @@ def test_get_alignments(cigar_string: str, maybe_range: Optional[range]) -> None
 )
 def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[range]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-    assert Cigar.get_query_alignment_offsets(cig, reverse=True) == maybe_range
+    assert Cigar.query_alignment_offsets(cig, reverse=True) == maybe_range

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -93,7 +93,9 @@ def test_query_alignment_offsets_failures(cigar_string: str) -> None:
         ("10H10S10M5S10H", (5, 15)),
     ],
 )
-def test_query_alignment_offsets_reversed(cigar_string: str, expected_range: Tuple[int, int]) -> None:
+def test_query_alignment_offsets_reversed(
+    cigar_string: str, expected_range: Tuple[int, int]
+) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
 
     ret = cig.reversed().query_alignment_offsets()

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import pytest
 
 from fgpyo.sam import Cigar
@@ -49,7 +51,7 @@ def test_bad_index_raises_type_error(index: int) -> None:
         ("76I", (0, 76)),
     ],
 )
-def test_query_alignment_offsets(cigar_string: str, expected_range: tuple) -> None:
+def test_query_alignment_offsets(cigar_string: str, expected_range: Tuple[int, int]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
     ret = cig.query_alignment_offsets()
     assert ret == expected_range
@@ -91,7 +93,7 @@ def test_query_alignment_offsets_failures(cigar_string: str) -> None:
         ("10H10S10M5S10H", (5, 15)),
     ],
 )
-def test_query_alignment_offsets_reversed(cigar_string: str, expected_range: tuple) -> None:
+def test_query_alignment_offsets_reversed(cigar_string: str, expected_range: Tuple[int, int]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
 
     ret = cig.reversed().query_alignment_offsets()

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -1,8 +1,10 @@
 from typing import Optional
+from typing import Tuple
 
 import pytest
 
 from fgpyo.sam import Cigar
+from fgpyo.sam import RangeOfBases
 
 cigar = Cigar.from_cigarstring("1M4D45N37X23I11=")
 
@@ -38,50 +40,54 @@ def test_bad_index_raises_type_error(index: int) -> None:
 @pytest.mark.parametrize(
     ("cigar_string", "maybe_range"),
     {
-        ("10M", range(0, 10)),
-        ("10M10I", range(0, 20)),
-        ("10X10I", range(0, 20)),
-        ("10X10D", range(0, 10)),
-        ("10=10D", range(0, 10)),
-        ("10S10M", range(10, 20)),
-        ("10H10M", range(0, 10)),
-        ("10H10S10M", range(10, 20)),
-        ("10H10S10M5S", range(10, 20)),
-        ("10H10S10M5S10H", range(10, 20)),
+        ("10M", RangeOfBases(0, 10)),
+        ("10M10I", RangeOfBases(0, 20)),
+        ("10X10I", RangeOfBases(0, 20)),
+        ("10X10D", RangeOfBases(0, 10)),
+        ("10=10D", RangeOfBases(0, 10)),
+        ("10S10M", RangeOfBases(10, 20)),
+        ("10H10M", RangeOfBases(0, 10)),
+        ("10H10S10M", RangeOfBases(10, 20)),
+        ("10H10S10M5S", RangeOfBases(10, 20)),
+        ("10H10S10M5S10H", RangeOfBases(10, 20)),
         ("10H", None),
         ("10S", None),
         ("10S10H", None),
         ("5H10S10H", None),
         ("76D", None),
-        ("76I", range(0, 76)),
+        ("76I", RangeOfBases(0, 76)),
         ("10P76S", None),
         ("50S1000N50S", None),
     },
 )
-def test_get_alignments(cigar_string: str, maybe_range: Optional[range]) -> None:
+def test_get_alignments(cigar_string: str, maybe_range: Optional[RangeOfBases]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
+
     assert Cigar.query_alignment_offsets(cig, reverse=False) == maybe_range
 
 
 @pytest.mark.parametrize(
     ("cigar_string", "maybe_range"),
     {
-        ("10M", range(0, 10)),
-        ("10M10I", range(0, 20)),
-        ("10X10I", range(0, 20)),
-        ("10X10D", range(0, 10)),
-        ("10=10D", range(0, 10)),
-        ("10S10M", range(0, 10)),
-        ("10H10M", range(0, 10)),
-        ("10H10S10M", range(0, 10)),
-        ("10H10S10M5S", range(5, 15)),
-        ("10H10S10M5S10H", range(5, 15)),
+        ("10M", RangeOfBases(0, 10)),
+        ("10M10I", RangeOfBases(0, 20)),
+        ("10X10I", RangeOfBases(0, 20)),
+        ("10X10D", RangeOfBases(0, 10)),
+        ("10=10D", RangeOfBases(0, 10)),
+        ("10S10M", RangeOfBases(0, 10)),
+        ("10H10M", RangeOfBases(0, 10)),
+        ("10H10S10M", RangeOfBases(0, 10)),
+        ("10H10S10M5S", RangeOfBases(5, 15)),
+        ("10H10S10M5S10H", RangeOfBases(5, 15)),
         ("10H", None),
         ("10S", None),
         ("10S10H", None),
         ("5H10S10H", None),
     },
 )
-def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[range]) -> None:
+def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[Tuple[int, int]]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
+
     assert Cigar.query_alignment_offsets(cig, reverse=True) == maybe_range
+    if maybe_range is not None:
+        start, stop = maybe_range

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -38,7 +38,7 @@ def test_bad_index_raises_type_error(index: int) -> None:
 
 @pytest.mark.parametrize(
     ("cigar_string", "maybe_range"),
-    {
+    [
         ("10M", (0, 10)),
         ("10M10I", (0, 20)),
         ("10X10I", (0, 20)),
@@ -57,7 +57,7 @@ def test_bad_index_raises_type_error(index: int) -> None:
         ("76I", (0, 76)),
         ("10P76S", None),
         ("50S1000N50S", None),
-    },
+    ],
 )
 def test_get_alignments(cigar_string: str, maybe_range: Optional[tuple]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
@@ -71,7 +71,7 @@ def test_get_alignments(cigar_string: str, maybe_range: Optional[tuple]) -> None
 
 @pytest.mark.parametrize(
     ("cigar_string", "maybe_range"),
-    {
+    [
         ("10M", (0, 10)),
         ("10M10I", (0, 20)),
         ("10X10I", (0, 20)),
@@ -86,7 +86,7 @@ def test_get_alignments(cigar_string: str, maybe_range: Optional[tuple]) -> None
         ("10S", None),
         ("10S10H", None),
         ("5H10S10H", None),
-    },
+    ],
 )
 def test_get_alignments_reversed(cigar_string: str, maybe_range: Optional[Tuple]) -> None:
     cig = Cigar.from_cigarstring(cigar_string)

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -54,7 +54,7 @@ def test_bad_index_raises_type_error(index: int) -> None:
 )
 def test_get_alignments(cigar_string: str, start: int, end: int) -> None:
     cig = Cigar.from_cigarstring(cigar_string)
-    assert Cigar.get_alignment_offsets(cig, False) == (start, end)
+    assert Cigar.get_alignment_offsets(cig, reverse=False) == (start, end)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- add cigar utility method get_alignment_offsets to find the offsets of the aligned segment in the read
- tests included