### PR TITLE
chore: Require error codes on `type: ignore` pragmas

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -266,7 +266,7 @@ def _pysam_open(
         else:
             file_type = file_type or SamFileType.from_path(path)
             path = str(path)
-    elif not isinstance(path, _IOClasses):  # type: ignore
+    elif not isinstance(path, _IOClasses):  # type: ignore[unreachable]
         open_type = "reading" if open_for_reading else "writing"
         raise TypeError(f"Cannot open '{type(path)}' for {open_type}.")
 

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -596,12 +596,12 @@ class SamBuilder:
             file_handle.close()
             if self._sort_order == SamOrder.QueryName:
                 # Ignore type hints for now until we have wrappers to use here.
-                pysam.sort("-n", *samtools_sort_args)  # type: ignore
+                pysam.sort("-n", *samtools_sort_args)  # type: ignore[attr-defined]
             elif self._sort_order == SamOrder.Coordinate:
                 # Ignore type hints for now until we have wrappers to use here.
                 if index:
                     samtools_sort_args.insert(0, "--write-index")
-                pysam.sort(*samtools_sort_args)  # type: ignore
+                pysam.sort(*samtools_sort_args)  # type: ignore[attr-defined]
 
         return path
 

--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -83,7 +83,7 @@ def reader(path: VcfPath) -> Generator[VcfReader, None, None]:
         with fgpyo.io.suppress_stderr():
             # to avoid spamming log about index older than vcf, redirect stderr to /dev/null: only
             # when first opening the file
-            _reader = VariantFile(path, mode="r")  # type: ignore
+            _reader = VariantFile(path, mode="r")  # type: ignore[arg-type]
         # now stderr is back, so any later stderr messages will go through
         yield _reader
         _reader.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,4 @@ warn_return_any             = true
 warn_unreachable            = true
 warn_unused_configs         = true
 warn_unused_ignores         = true
+enable_error_code           = "ignore-without-code"

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -149,7 +149,7 @@ def test_sam_file_open_writing(
             path=fp.file,
             open_for_reading=False,
             file_type=file_type,
-            **kwargs,  # type: ignore
+            **kwargs,  # type: ignore[arg-type]
         ) as sam_writer:
             for r in expected_records:
                 sam_writer.write(r)

--- a/tests/fgpyo/util/test_inspect.py
+++ b/tests/fgpyo/util/test_inspect.py
@@ -126,10 +126,10 @@ def test_non_data_class_fails() -> None:
         x: int
 
     with pytest.raises(TypeError):
-        get_fields_dict(NonDataClass)  # type: ignore
+        get_fields_dict(NonDataClass)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        get_fields(NonDataClass)  # type: ignore
+        get_fields(NonDataClass)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
         attr_from(cls=NonDataClass, kwargs={"x": "1"}, parsers={int: int})


### PR DESCRIPTION
This PR adds the mypy config introduced into our template in https://github.com/fulcrumgenomics/python-template/pull/28.

Error codes are now required on any `type: ignore` pragmas. This PR also adds error codes to any existing `ignore`s without a code.