### PR TITLE
chore: Add docstring lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,26 @@ target-version = "py38"
 output-format  = "full"
 
 [tool.ruff.lint]
-select    = ["C901", "B", "E", "F", "I", "W", "Q"]
-ignore    = ["E203", "E701"]
+select    = [
+    "C901",
+    "B",
+    "D",     # pydocstyle (docstrings. We have the "google" convention enabled)
+    "D204",  # Blank line between class docstring and first (__init__) method
+    "D213",  # Summary line should be located on the line after opening quotes
+    "D401",  # Summary line should be in imperative tense.
+    "E",
+    "F",
+    "I",
+    "W",
+    "Q"
+]
+ignore    = [
+    "E203",
+    "E701",
+    "D212",  # summary line should be located on the same line as opening quotes
+    "D100",  # missing docstring in public module
+    "D104",  # missing docstring in public package
+]
 unfixable = ["B"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ unfixable = ["B"]
 [tool.ruff.lint.isort]
 force-single-line = true
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D"]
+
 [tool.mypy]
 python_version              = 3.8
 strict_optional             = false


### PR DESCRIPTION
Closes #192 

## Summary

This PR introduces the [pydocstyle lints](https://docs.astral.sh/ruff/rules/#pydocstyle-d) as [configured in our Python template](https://github.com/fulcrumgenomics/python-template/pull/15).

There are currently 672 errors flagged by these rules. This is a somewhat daunting amount and I'd appreciate any PRs based against this branch to help chip away at these.