### PR TITLE
feat: Add sorted Cartesian product

### DIFF
--- a/fgpyo/util/itertools.py
+++ b/fgpyo/util/itertools.py
@@ -1,15 +1,91 @@
+import heapq
 from dataclasses import dataclass
-from typing import TypeVar, Callable, Iterable, Iterator
+from dataclasses import field
+from typing import Callable
+from typing import Collection
+from typing import Generic
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import TypeVar
 
-T = TypeVar('T')
+T = TypeVar("T")
+
+
+@dataclass(order=True)
+class Coord:
+    x: int
+    y: int
+
+    def incr_x(self) -> "Coord":
+        return Coord(self.x + 1, self.y)
+
+    def incr_y(self) -> "Coord":
+        return Coord(self.x, self.y + 1)
+
+
+@dataclass(order=True)
+class HeapElem(Generic[T]):
+    _priority: float
+    val: Tuple[T, T] = field(compare=False)
+    coord: Coord  # NB: sorting must also be stable / deterministic on the coordinates
+
+    @classmethod
+    def new(cls, x: T, y: T, coord: Coord, priority: Callable[[T], float]) -> "HeapElem":
+        return cls(_priority=priority(x) + priority(y), val=(x, y), coord=coord)
+
+
+class ProductSumTable(Generic[T]):
+    xs: List[T]
+    ys: List[T]
+    priority: Callable[[T], float]
+
+    def __init__(self, xs: Iterable[T], ys: Iterable[T], priority: Callable[[T], float]) -> None:
+        self.xs = list(xs)
+        self.ys = list(ys)
+        self.priority = priority
+
+    def has_right(self, elem: HeapElem) -> bool:
+        return (elem.coord.x + 1) < len(self.xs)
+
+    def has_down(self, elem: HeapElem) -> bool:
+        return (elem.coord.y + 1) < len(self.ys)
+
+    def is_last(self, elem: HeapElem) -> bool:
+        return (elem.coord.y + 1) == len(self.ys) and (elem.coord.x + 1) == len(self.xs)
+
+    def get_elem(self, coord: Coord) -> HeapElem:
+        x: T = self.xs[coord.x]
+        y: T = self.ys[coord.y]
+
+        return HeapElem.new(x=x, y=y, coord=coord, priority=self.priority)
+
+    def get_right(self, elem: HeapElem) -> HeapElem:
+        assert self.has_right(elem)
+        coord = elem.coord.incr_x()
+        return self.get_elem(coord)
+
+    def get_down(self, elem: HeapElem) -> HeapElem:
+        assert self.has_down(elem)
+        coord = elem.coord.incr_y()
+        return self.get_elem(coord)
+
+    def get_last(self) -> HeapElem:
+        x: T = self.xs[-1]
+        y: T = self.ys[-1]
+
+        return HeapElem.new(
+            x=x, y=y, coord=Coord(len(self.xs) - 1, len(self.ys) - 1), priority=self.priority
+        )
 
 
 def sorted_product(
-    xs: Iterable[T],
-    ys: Iterable[T],
+    xs: Collection[T],
+    ys: Collection[T],
     priority: Callable[[T], float],
-    limit: int | None = None,
-) -> Iterator[tuple[T, T]]:
+    limit: Optional[int] = None,
+) -> List[Tuple[T, T]]:
     """
     Efficient generation of the sorted Cartesian product of two sorted lists.
 
@@ -23,3 +99,71 @@ def sorted_product(
         Each tuple (x, y) from the Cartesian product of xs and ys, sorted by the sum of the priority
         of x and y.
     """
+
+    table: ProductSumTable = ProductSumTable(xs=xs, ys=ys, priority=priority)
+    curr: HeapElem[T] = table.get_elem(Coord(x=0, y=0))
+
+    # Each heap element corresponds to a single pairing in the product.
+    # `heap` contains the current heap, and `result` contains the sorted pairings generated so far.
+    heap: List[HeapElem[T]] = []
+    result: List[HeapElem[T]] = []
+
+    # If no limit is specified, generate all elements.
+    if limit is None:
+        limit = len(xs) * len(ys)
+
+    # TODO: yield instead of generating `results` list
+    while not table.is_last(curr) and len(result) < limit:
+        result.append(curr)
+        if len(heap) > 0:
+            if heap[0].coord == curr.coord:
+                heapq.heappop(heap)
+
+        if len(heap) > 0:
+            top = heap[0]
+            if not table.has_right(curr) and table.has_down(curr):
+                down = table.get_down(curr)
+                if down < top:
+                    curr = down
+                else:
+                    curr = heapq.heappushpop(heap, down)
+            elif table.has_right(curr) and not table.has_down(curr):
+                right = table.get_right(curr)
+                if right <= top:
+                    curr = right
+                else:
+                    curr = heapq.heappushpop(heap, right)
+            else:
+                down = table.get_down(curr)
+                right = table.get_right(curr)
+
+                if right <= down and right <= top:
+                    curr = right
+                    heapq.heappush(heap, down)
+                elif down <= right and down <= top:
+                    curr = down
+                    heapq.heappush(heap, right)
+                else:
+                    curr = heapq.heappushpop(heap, down)
+                    heapq.heappush(heap, right)
+        else:
+            if not table.has_right(curr) and table.has_down(curr):
+                curr = table.get_down(curr)
+            elif table.has_right(curr) and not table.has_down(curr):
+                curr = table.get_right(curr)
+            else:
+                right = table.get_right(curr)
+                down = table.get_down(curr)
+                if right <= down:
+                    heapq.heappush(heap, down)
+                    curr = right
+                else:
+                    heapq.heappush(heap, right)
+                    curr = down
+
+    result.append(curr)
+
+    if len(heap) > 0 and heap[0].coord != curr.coord:
+        result.append(heap[0])
+
+    return [elem.val for elem in result]

--- a/fgpyo/util/itertools.py
+++ b/fgpyo/util/itertools.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import TypeVar, Callable, Iterable, Iterator
+
+T = TypeVar('T')
+
+
+def sorted_product(
+    xs: Iterable[T],
+    ys: Iterable[T],
+    priority: Callable[[T], float],
+    limit: int | None = None,
+) -> Iterator[tuple[T, T]]:
+    """
+    Efficient generation of the sorted Cartesian product of two sorted lists.
+
+    Args:
+        xs: A sorted list of elements.
+        ys: A sorted list of elements.
+        priority: A function that assigns a priority to each element.
+        limit: If specified, only the first `limit` elements of the product will be generated.
+
+    Yields:
+        Each tuple (x, y) from the Cartesian product of xs and ys, sorted by the sum of the priority
+        of x and y.
+    """

--- a/fgpyo/util/itertools.py
+++ b/fgpyo/util/itertools.py
@@ -15,18 +15,36 @@ T = TypeVar("T")
 
 @dataclass(order=True)
 class Coord:
+    """
+    Index a position in the ProductSumTable, a 2-D grid.
+
+    Attributes:
+        x: The x-coordinate (or index into the array of `xs`).
+        y: The y-coordinate (or index into the array of `ys`).
+    """
     x: int
     y: int
 
     def incr_x(self) -> "Coord":
+        """Return a new Coord with the same y-coordinate and the x-coordinate incremented by 1."""
         return Coord(self.x + 1, self.y)
 
     def incr_y(self) -> "Coord":
+        """Return a new Coord with the same x-coordinate and the y-coordinate incremented by 1."""
         return Coord(self.x, self.y + 1)
 
 
 @dataclass(order=True)
 class HeapElem(Generic[T]):
+    """
+    A heap element that contains a pairing of elements in the Cartesian product.
+
+    Attributes:
+        _priority: The priority of this element, which is the sum of the priorities of the paired
+            elements.
+        val: The paired elements.
+        coord: The position in the ProductSumTable.
+    """
     _priority: float
     val: Tuple[T, T] = field(compare=False)
     coord: Coord  # NB: sorting must also be stable / deterministic on the coordinates
@@ -37,6 +55,14 @@ class HeapElem(Generic[T]):
 
 
 class ProductSumTable(Generic[T]):
+    """
+    A 2-D grid of elements that supports efficient traversal of the sorted Cartesian product.
+
+    Attributes:
+        xs: A sorted list of elements.
+        ys: A sorted list of elements.
+        priority: A function that returns a numeric priority for each element.
+    """
     xs: List[T]
     ys: List[T]
     priority: Callable[[T], float]
@@ -100,7 +126,7 @@ def sorted_product(
         of x and y.
     """
 
-    table: ProductSumTable = ProductSumTable(xs=xs, ys=ys, priority=priority)
+    table: ProductSumTable[T] = ProductSumTable(xs=xs, ys=ys, priority=priority)
     curr: HeapElem[T] = table.get_elem(Coord(x=0, y=0))
 
     # Each heap element corresponds to a single pairing in the product.

--- a/tests/fgpyo/util/test_itertools.py
+++ b/tests/fgpyo/util/test_itertools.py
@@ -1,0 +1,22 @@
+from itertools import product
+from typing import List
+from typing import Tuple
+
+from typing_extensions import TypeAlias
+
+from fgpyo.util.itertools import sorted_product
+
+
+def test_sorted_product() -> None:
+    """sorted_product should return a sorted cartesian product of the input lists."""
+    xs: List[int] = [25, 10, 10, 1]
+    ys: List[int] = [1, 2, 10]
+
+    Pairing: TypeAlias = Tuple[int, int]
+    actual_product: List[Pairing] = list(sorted_product(xs, ys, priority=lambda x: float(x)))
+
+    # We should get the same result as using `itertools.product` and then sorting, the
+    # implementation is just more efficient (in most cases).
+    expected_product: List[Pairing] = sorted(product(xs, ys), key=lambda tup: tup[0] + tup[1], reverse=True)
+
+    assert actual_product == expected_product

--- a/tests/fgpyo/util/test_itertools.py
+++ b/tests/fgpyo/util/test_itertools.py
@@ -17,6 +17,8 @@ def test_sorted_product() -> None:
 
     # We should get the same result as using `itertools.product` and then sorting, the
     # implementation is just more efficient (in most cases).
-    expected_product: List[Pairing] = sorted(product(xs, ys), key=lambda tup: tup[0] + tup[1], reverse=True)
+    expected_product: List[Pairing] = sorted(
+        product(xs, ys), key=lambda tup: tup[0] + tup[1], reverse=True
+    )
 
     assert actual_product == expected_product


### PR DESCRIPTION
This PR implements a generic version of the algorithm Jason outlined to efficiently produce the sorted Cartesian product of two sorted input collections.

Original implementation: https://gist.github.com/theJasonFan/b84f8036855bf4e0eff15a1c654283c5