### PR TITLE
chore: exclude `site/` and `docs/` from mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,4 @@ warn_unreachable            = true
 warn_unused_configs         = true
 warn_unused_ignores         = true
 enable_error_code           = "ignore-without-code"
+exclude                     = ["site/", "docs/"]


### PR DESCRIPTION
Otherwise `mypy` fails locally.