### PR TITLE
ci: migrate ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   testing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/readthedocs.yaml
+++ b/.github/workflows/readthedocs.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   documentation-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: readthedocs/actions/preview@v1
         with:


### PR DESCRIPTION
Removes CI checks for Python 3.8 (see https://github.com/fulcrumgenomics/fgpyo/issues/187)