### PR TITLE
Add a method for progress logging multiple alignments

### DIFF
--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -45,8 +45,6 @@ from typing import Union
 
 from pysam import AlignedSegment
 
-from fgpyo.sam import Template
-
 # Global that is set to True once logging initialization is run to prevent running > once.
 __FGPYO_LOGGING_SETUP: bool = False
 

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -44,6 +44,8 @@ from typing import Union
 
 from pysam import AlignedSegment
 
+from fgpyo.sam import Template
+
 # Global that is set to True once logging initialization is run to prevent running > once.
 __FGPYO_LOGGING_SETUP: bool = False
 
@@ -162,6 +164,23 @@ class ProgressLogger(AbstractContextManager):
             return self.record(None, None)
         else:
             return self.record(rec.reference_name, rec.reference_start + 1)
+
+    def record_template(
+        self,
+        template: Template,
+    ) -> bool:
+        """Correctly record all records in a fgpyo.sam.Template (zero-based coordinates).
+
+        Args:
+            template: fgpyo.sam.Template objects
+
+        Returns:
+            true if a message was logged, false otherwise
+        """
+        logged_message: bool = False
+        for rec in template.all_recs():
+            logged_message = self.record_alignment(rec) or logged_message
+        return logged_message
 
     def _log(
         self,

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -38,6 +38,7 @@ from logging import Logger
 from threading import RLock
 from typing import Any
 from typing import Callable
+from typing import Iterable
 from typing import Literal
 from typing import Optional
 from typing import Union
@@ -165,20 +166,20 @@ class ProgressLogger(AbstractContextManager):
         else:
             return self.record(rec.reference_name, rec.reference_start + 1)
 
-    def record_template(
+    def record_alignments(
         self,
-        template: Template,
+        recs: Iterable[AlignedSegment],
     ) -> bool:
-        """Correctly record all records in a fgpyo.sam.Template (zero-based coordinates).
+        """Correctly record multiple pysam.AlignedSegments (zero-based coordinates).
 
         Args:
-            template: fgpyo.sam.Template objects
+            recs: pysam.AlignedSegment objects
 
         Returns:
             true if a message was logged, false otherwise
         """
         logged_message: bool = False
-        for rec in template.all_recs():
+        for rec in recs:
             logged_message = self.record_alignment(rec) or logged_message
         return logged_message
 

--- a/tests/fgpyo/util/test_logging.py
+++ b/tests/fgpyo/util/test_logging.py
@@ -62,7 +62,7 @@ def test_record_alignment_mapped_record(record: pysam.AlignedSegment) -> None:
     assert progress.record_alignment(rec=record) is True
 
 
-def test_record_template() -> None:
+def test_record_multiple_alignments() -> None:
     builder: SamBuilder = SamBuilder()
     (r1, r2) = builder.add_pair(name="x", chrom="chr1", start1=1, start2=2)
     (r1_secondary, r2_secondary) = builder.add_pair(name="x", chrom="chr1", start1=10, start2=12)
@@ -95,7 +95,7 @@ def test_record_template() -> None:
     )
 
     # Assert record is logged
-    assert progress.record_template(template=expected) is True
+    assert progress.record_alignments(recs=template.all_recs()) is True
 
     # Assert every record was logged
     assert len(actual) == 6


### PR DESCRIPTION
Often I am iterating through a BAM by query name and find I'm having to manually loop over all records to increment the progress logger. This new method would make logging all the records in a template more convenient.