### PR TITLE
Add all_r1 and all_r2 methods on Template

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -158,6 +158,7 @@ and slices):
 import enum
 import io
 import sys
+from itertools import chain
 from pathlib import Path
 from typing import IO
 from typing import Any
@@ -939,6 +940,16 @@ class Template:
     def primary_recs(self) -> Iterator[AlignedSegment]:
         """Returns a list with all the primary records for the template."""
         return (r for r in (self.r1, self.r2) if r is not None)
+
+    def all_r1s(self) -> Iterator[AlignedSegment]:
+        """Yields all R1 alignments of this template including secondary and supplementary."""
+        r1_primary = [] if self.r1 is None else [self.r1]
+        return chain(r1_primary, self.r1_secondaries, self.r1_supplementals)
+
+    def all_r2s(self) -> Iterator[AlignedSegment]:
+        """Yields all R2 alignments of this template including secondary and supplementary."""
+        r2_primary = [] if self.r2 is None else [self.r2]
+        return chain(r2_primary, self.r2_secondaries, self.r2_supplementals)
 
     def all_recs(self) -> Iterator[AlignedSegment]:
         """Returns a list with all the records for the template."""

--- a/tests/fgpyo/sam/test_template_iterator.py
+++ b/tests/fgpyo/sam/test_template_iterator.py
@@ -29,6 +29,34 @@ def test_template_init_function() -> None:
     assert len([t for t in template.r1_secondaries]) == 0
 
 
+def test_all_r1_and_all_r2() -> None:
+    builder: SamBuilder = SamBuilder()
+    (r1, r2) = builder.add_pair(name="x", chrom="chr1", start1=1, start2=2)
+    (r1_secondary, r2_secondary) = builder.add_pair(name="x", chrom="chr1", start1=10, start2=12)
+    r1_secondary.is_secondary = True
+    r2_secondary.is_secondary = True
+    (r1_supplementary, r2_supplementary) = builder.add_pair(
+        name="x", chrom="chr1", start1=4, start2=6
+    )
+    r1_supplementary.is_supplementary = True
+    r2_supplementary.is_supplementary = True
+
+    template = Template.build(builder.to_unsorted_list())
+    expected = Template(
+        name="x",
+        r1=r1,
+        r2=r2,
+        r1_secondaries=[r1_secondary],
+        r2_secondaries=[r2_secondary],
+        r1_supplementals=[r1_supplementary],
+        r2_supplementals=[r2_supplementary],
+    )
+
+    assert template == expected
+    assert list(template.all_r1s()) == [r1, r1_secondary, r1_supplementary]
+    assert list(template.all_r2s()) == [r2, r2_secondary, r2_supplementary]
+
+
 def test_to_templates() -> None:
     builder = SamBuilder()
 


### PR DESCRIPTION
Having a view into the R1 alignments or R2 alignments without having to manually chain the iterables each time would be helpful for dealing with complex alignment scenarios. Would these two methods be a welcome addition?