### PR TITLE
Template to treat 'secondary supplemental' as supplemental

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -883,7 +883,7 @@ class Template:
                     r1_supplementals.append(rec)
                 else:
                     r2_supplementals.append(rec)
-            if rec.is_secondary:
+            elif rec.is_secondary:
                 if is_r1:
                     r1_secondaries.append(rec)
                 else:

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -830,14 +830,17 @@ class Template:
     validations of the Template by default.  If constructing Template instances by construction
     users are encouraged to use the validate method post-construction.
 
+    In the special cases there are alignments records that are _*both secondary and supplementary*_
+    then they will be stored upon the `r1_supplementals` and `r2_supplementals` fields only.
+
     Attributes:
         name: the name of the template/query
-        r1: Primary alignment for read 1, or None if there is none
-        r2: Primary alignment for read 2, or None if there is none
+        r1: Primary non-supplementary alignment for read 1, or None if there is none
+        r2: Primary non-supplementary alignment for read 2, or None if there is none
         r1_supplementals: Supplementary alignments for read 1
         r2_supplementals: Supplementary alignments for read 2
-        r1_secondaries: Secondary (non-primary) alignments for read 1
-        r2_secondaries: Secondary (non-primary) alignments for read 2
+        r1_secondaries: Secondary (non-primary, non-supplementary) alignments for read 1
+        r2_secondaries: Secondary (non-primary, non-supplementary) alignments for read 2
     """
 
     name: str
@@ -924,6 +927,7 @@ class Template:
         for rec in self.r1_secondaries:
             assert rec.is_read1 or not rec.is_paired, "R1 secondary not flagged as R1 or unpaired"
             assert rec.is_secondary, "R1 secondary not flagged as secondary"
+            assert not rec.is_supplementary, "R1 secondary supplementals belong with supplementals"
 
         for rec in self.r1_supplementals:
             assert rec.is_read1 or not rec.is_paired, "R1 supp. not flagged as R1 or unpaired"
@@ -932,6 +936,7 @@ class Template:
         for rec in self.r2_secondaries:
             assert rec.is_read2, "R2 secondary not flagged as R2"
             assert rec.is_secondary, "R2 secondary not flagged as secondary"
+            assert not rec.is_supplementary, "R2 secondary supplementals belong with supplementals"
 
         for rec in self.r2_supplementals:
             assert rec.is_read2, "R2 supp. not flagged as R2"

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -265,7 +265,8 @@ def _pysam_open(
             assert file_type is not None, "Must specify file_type when writing to standard output"
             path = sys.stdout
         else:
-            file_type = file_type or SamFileType.from_path(path)
+            if file_type is None:
+                file_type = SamFileType.from_path(path)
             path = str(path)
     elif not isinstance(path, _IOClasses):  # type: ignore[unreachable]
         open_type = "reading" if open_for_reading else "writing"

--- a/tests/fgpyo/sam/test_template_iterator.py
+++ b/tests/fgpyo/sam/test_template_iterator.py
@@ -131,6 +131,51 @@ def test_write_template(
         assert len([r for r in template.all_recs()]) == 2
 
 
+def test_template_treats_secondary_supplementary_as_supplementary() -> None:
+    """Test that Template treats "secondary supplementaries" as supplementary."""
+    builder = SamBuilder()
+
+    r1, r2 = builder.add_pair(name="x", chrom="chr1", start1=10, start2=30)
+    r1_secondary, r2_secondary = builder.add_pair(name="x", chrom="chr1", start1=2, start2=5)
+    r1_secondary.is_secondary = True
+    r2_secondary.is_secondary = True
+
+    r1_supp, r2_supp = builder.add_pair(name="x", chrom="chr1", start1=2, start2=3)
+    r1_supp.is_supplementary = True
+    r2_supp.is_supplementary = True
+
+    r1_secondary_supp, r2_secondary_supp = builder.add_pair(
+        name="x", chrom="chr1", start1=2, start2=3
+    )
+    r1_secondary_supp.is_secondary = True
+    r2_secondary_supp.is_secondary = True
+    r1_secondary_supp.is_supplementary = True
+    r2_secondary_supp.is_supplementary = True
+
+    actual = Template.build(
+        [
+            r1,
+            r2,
+            r1_secondary,
+            r2_secondary,
+            r1_supp,
+            r2_supp,
+            r1_secondary_supp,
+            r2_secondary_supp,
+        ]
+    )
+    expected = Template(
+        name="x",
+        r1=r1,
+        r2=r2,
+        r1_secondaries=[r1_secondary],
+        r2_secondaries=[r2_secondary],
+        r1_supplementals=[r1_supp, r1_secondary_supp],
+        r2_supplementals=[r2_supp, r2_secondary_supp],
+    )
+    assert actual == expected
+
+
 def test_set_tag() -> None:
     builder = SamBuilder()
     template = Template.build(builder.add_pair(chrom="chr1", start1=100, start2=200))

--- a/tests/fgpyo/sam/test_template_iterator.py
+++ b/tests/fgpyo/sam/test_template_iterator.py
@@ -131,6 +131,23 @@ def test_write_template(
         assert len([r for r in template.all_recs()]) == 2
 
 
+def test_template_can_set_r1_and_r2_with_no_secondary_or_supplementals() -> None:
+    """Test that we can build a template with just an R1 and R2 primary alignment."""
+    builder = SamBuilder()
+    r1, r2 = builder.add_pair(name="x", chrom="chr1", start1=10, start2=30)
+    actual = Template.build([r1, r2])
+    expected = Template(
+        name="x",
+        r1=r1,
+        r2=r2,
+        r1_secondaries=[],
+        r2_secondaries=[],
+        r1_supplementals=[],
+        r2_supplementals=[],
+    )
+    assert actual == expected
+
+
 def test_template_treats_secondary_supplementary_as_supplementary() -> None:
     """Test that Template treats "secondary supplementaries" as supplementary."""
     builder = SamBuilder()


### PR DESCRIPTION
Currently, `Template` treats "secondary supplemental" alignments as both secondary alignments and as supplemental alignments. Before this PR, `Template` would _**add**_ the "secondary supplemental" alignments into both the secondary and supplementary lists, thereby duplicating them. This behavior makes it difficult to use `Template` in complex alignment scenarios since there are duplicated records across both the secondary and supplementary lists e.g. records become duplicated when writing to a BAM file with `template.write_to(writer)`.

It would be more intuitive to me that supplemental alignments of a secondary alignment belong in the "supplementary" bin instead of both the secondary and the supplementary bin. With this PR, the fields of Template become more specific:

- Primary: all primary non-supplementary alignments
- Secondary: all secondary non-supplementary alignments
- Supplementary: all supplementary alignments

For context, I have a situation where I am intentionally creating and comparing primary and secondary alignments, each having a chimeric alignment (e.g. an alignment across different reference sequences), and having to de-duplicate the supplemental records from both the secondary and supplementary bins is error-prone and a lot of work.