### PR TITLE
feat: trim flanking whitespace when reading a metric

### DIFF
--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -211,7 +211,7 @@ class Metric(ABC, Generic[MetricType]):
 
     @classmethod
     def read(
-        cls, path: Path, ignore_extra_fields: bool = True, strip_whitespace: bool = True
+        cls, path: Path, ignore_extra_fields: bool = True, strip_whitespace: bool = False
     ) -> Iterator[Any]:
         """Reads in zero or more metrics from the given path.
 
@@ -223,7 +223,8 @@ class Metric(ABC, Generic[MetricType]):
         Args:
             path: the path to the metrics file.
             ignore_extra_fields: True to ignore any extra columns, False to raise an exception.
-            strip_whitespace: True to strip leading and trailing whitespace, False to keep as-is.
+            strip_whitespace: True to strip leading and trailing whitespace from each field, 
+                               False to keep as-is.
         """
         parsers = cls._parsers()
         with io.to_reader(path) as reader:
@@ -358,7 +359,7 @@ class Metric(ABC, Generic[MetricType]):
                     + "}"
                 )
         elif isinstance(value, float):
-            return f"{round(value, 5)}".strip()
+            return f"{round(value, 5)}"
         elif value is None:
             return ""
         else:

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -210,7 +210,9 @@ class Metric(ABC, Generic[MetricType]):
         return {}
 
     @classmethod
-    def read(cls, path: Path, ignore_extra_fields: bool = True) -> Iterator[Any]:
+    def read(
+        cls, path: Path, ignore_extra_fields: bool = True, strip_whitespace: bool = True
+    ) -> Iterator[Any]:
         """Reads in zero or more metrics from the given path.
 
         The metric file must contain a matching header.
@@ -221,6 +223,7 @@ class Metric(ABC, Generic[MetricType]):
         Args:
             path: the path to the metrics file.
             ignore_extra_fields: True to ignore any extra columns, False to raise an exception.
+            strip_whitespace: True to strip leading and trailing whitespace, False to keep as-is.
         """
         parsers = cls._parsers()
         with io.to_reader(path) as reader:
@@ -263,6 +266,8 @@ class Metric(ABC, Generic[MetricType]):
             for lineno, line in enumerate(reader, 2):
                 # parse the raw values
                 values: List[str] = line.rstrip("\r\n").split("\t")
+                if strip_whitespace:
+                    values = [v.strip() for v in values]
 
                 # raise an exception if there aren't the same number of values as the header
                 if len(header) != len(values):
@@ -353,11 +358,11 @@ class Metric(ABC, Generic[MetricType]):
                     + "}"
                 )
         elif isinstance(value, float):
-            return str(round(value, 5))
+            return f"{round(value, 5)}".strip()
         elif value is None:
             return ""
         else:
-            return str(value)
+            return f"{value}"
 
     @classmethod
     def to_list(cls, value: str) -> List[Any]:

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -223,7 +223,7 @@ class Metric(ABC, Generic[MetricType]):
         Args:
             path: the path to the metrics file.
             ignore_extra_fields: True to ignore any extra columns, False to raise an exception.
-            strip_whitespace: True to strip leading and trailing whitespace from each field, 
+            strip_whitespace: True to strip leading and trailing whitespace from each field,
                                False to keep as-is.
         """
         parsers = cls._parsers()

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -427,20 +427,20 @@ def test_metric_strips_trailing_whitespace(tmp_path: Path, data_and_classes: Dat
 
     persons = list(data_and_classes.Person.read(test_tsv))
     assert len(persons) == 3
-    assert persons[0].name == "John Doe"
-    assert persons[0].age == 42
-    assert persons[1].name == "Jane Doe"
-    assert persons[1].age == 35
-    assert persons[2].name == "Someone Else"
-    assert persons[2].age == 47
-
-    persons = list(data_and_classes.Person.read(test_tsv, strip_whitespace=False))
-    assert len(persons) == 3
     assert persons[0].name == " John Doe "
     assert persons[0].age == 42
     assert persons[1].name == "Jane Doe"
     assert persons[1].age == 35
     assert persons[2].name == " Someone Else "
+    assert persons[2].age == 47
+
+    persons = list(data_and_classes.Person.read(test_tsv, strip_whitespace=True))
+    assert len(persons) == 3
+    assert persons[0].name == "John Doe"
+    assert persons[0].age == 42
+    assert persons[1].name == "Jane Doe"
+    assert persons[1].age == 35
+    assert persons[2].name == "Someone Else"
     assert persons[2].age == 47
 
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -434,6 +434,15 @@ def test_metric_strips_trailing_whitespace(tmp_path: Path, data_and_classes: Dat
     assert persons[2].name == "Someone Else"
     assert persons[2].age == 47
 
+    persons = list(data_and_classes.Person.read(test_tsv, strip_whitespace=False))
+    assert len(persons) == 3
+    assert persons[0].name == " John Doe "
+    assert persons[0].age == 42
+    assert persons[1].name == "Jane Doe"
+    assert persons[1].age == 35
+    assert persons[2].name == " Someone Else "
+    assert persons[2].age == 47
+
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_items(data_and_classes: DataBuilder) -> None:

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -155,6 +155,11 @@ class DataBuilder:
             age: int = 0
 
         @make_dataclass(use_attr=use_attr)
+        class PersonAgeFloat(Metric["PersonAgeFloat"]):
+            name: Optional[str]
+            age: Optional[float]
+
+        @make_dataclass(use_attr=use_attr)
         class ListPerson(Metric["ListPerson"]):
             name: List[Optional[str]]
             age: List[Optional[int]]
@@ -401,6 +406,33 @@ def test_metric_keys(data_and_classes: DataBuilder) -> None:
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_values(data_and_classes: DataBuilder) -> None:
     assert list(data_and_classes.Person(name="name", age=42).values()) == ["name", 42]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_round_floats(data_and_classes: DataBuilder) -> None:
+    assert list(data_and_classes.Person(name="John Doe", age=42.123456).formatted_values()) == [
+        "John Doe",
+        "42.12346",
+    ]
+
+
+@pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
+def test_metric_strips_trailing_whitespace(tmp_path: Path, data_and_classes: DataBuilder) -> None:
+    test_tsv = tmp_path / "test.tsv"
+    with test_tsv.open("w") as fout:
+        fout.write("name\tage\n")
+        fout.write(" John Doe \t42\n")  # whitespace around name
+        fout.write("Jane Doe\t 35 \n")  # whitespace around age
+        fout.write(" Someone Else \t 47 \n")  # whitespace around both
+
+    persons = list(data_and_classes.Person.read(test_tsv))
+    assert len(persons) == 3
+    assert persons[0].name == "John Doe"
+    assert persons[0].age == 42
+    assert persons[1].name == "Jane Doe"
+    assert persons[1].age == 35
+    assert persons[2].name == "Someone Else"
+    assert persons[2].age == 47
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))


### PR DESCRIPTION
Fixes #216
    
Also, strips any flanking whitespace when formatting a float into a string.