### PR TITLE
feat: allow lineterminator specification in MetricWriter

### DIFF
--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -450,7 +450,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         delimiter: str = "\t",
         include_fields: Optional[List[str]] = None,
         exclude_fields: Optional[List[str]] = None,
-        **kwargs: Any,
+        lineterminator: str = "\n",
     ) -> None:
         """
         Args:
@@ -465,7 +465,8 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             exclude_fields: If specified, any listed fieldnames will be excluded when writing
                 records to file.
                 May not be used together with `include_fields`.
-            kwargs: any keyword arguments to be passed to csv.DictWriter.
+            lineterminator: The string used to terminate lines produced by the MetricWriter.
+                Default = "\n".
 
         Raises:
             TypeError: If the provided metric class is not a dataclass- or attr-decorated
@@ -508,7 +509,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             f=self._fout,
             fieldnames=self._fieldnames,
             delimiter=delimiter,
-            **kwargs,
+            lineterminator=lineterminator,
         )
 
         # If we aren't appending to an existing file, write the header before any rows

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -450,6 +450,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         delimiter: str = "\t",
         include_fields: Optional[List[str]] = None,
         exclude_fields: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> None:
         """
         Args:
@@ -464,6 +465,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             exclude_fields: If specified, any listed fieldnames will be excluded when writing
                 records to file.
                 May not be used together with `include_fields`.
+            kwargs: any keyword arguments to be passed to csv.DictWriter.
 
         Raises:
             TypeError: If the provided metric class is not a dataclass- or attr-decorated
@@ -506,6 +508,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             f=self._fout,
             fieldnames=self._fieldnames,
             delimiter=delimiter,
+            **kwargs,
         )
 
         # If we aren't appending to an existing file, write the header before any rows

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -613,7 +613,26 @@ def test_writer_from_str(tmp_path: Path) -> None:
 
     with fpath.open("r") as f:
         assert next(f) == "foo\tbar\n"
+        assert repr(f.newlines) == repr("\r\n")
         assert next(f) == "abc\t1\n"
+        with pytest.raises(StopIteration):
+            next(f)
+
+
+def test_writer_with_kwargs(tmp_path: Path) -> None:
+    fpath = tmp_path / "test.txt"
+
+    with MetricWriter(
+        filename=fpath, append=False, metric_class=FakeMetric, lineterminator="\n"
+    ) as writer:
+        writer.write(FakeMetric(foo="abc", bar=1))
+        writer.write(FakeMetric(foo="def", bar=2))
+
+    with fpath.open("r") as f:
+        assert next(f) == "foo\tbar\n"
+        assert repr(f.newlines) == repr("\n")
+        assert next(f) == "abc\t1\n"
+        assert next(f) == "def\t2\n"
         with pytest.raises(StopIteration):
             next(f)
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -613,26 +613,24 @@ def test_writer_from_str(tmp_path: Path) -> None:
 
     with fpath.open("r") as f:
         assert next(f) == "foo\tbar\n"
-        assert repr(f.newlines) == repr("\r\n")
         assert next(f) == "abc\t1\n"
         with pytest.raises(StopIteration):
             next(f)
 
 
-def test_writer_with_kwargs(tmp_path: Path) -> None:
+@pytest.mark.parametrize("lineterminator", ["\n", "\r", "\r\n"])
+def test_writer_lineterminator(tmp_path: Path, lineterminator: str) -> None:
     fpath = tmp_path / "test.txt"
 
     with MetricWriter(
-        filename=fpath, append=False, metric_class=FakeMetric, lineterminator="\n"
+        filename=fpath, append=False, metric_class=FakeMetric, lineterminator=lineterminator
     ) as writer:
         writer.write(FakeMetric(foo="abc", bar=1))
-        writer.write(FakeMetric(foo="def", bar=2))
 
     with fpath.open("r") as f:
         assert next(f) == "foo\tbar\n"
-        assert repr(f.newlines) == repr("\n")
+        assert repr(f.newlines) == repr(lineterminator)
         assert next(f) == "abc\t1\n"
-        assert next(f) == "def\t2\n"
         with pytest.raises(StopIteration):
             next(f)
 


### PR DESCRIPTION
I stumbled upon the fact that `csv.DictWriter` uses windows  new line endings by default. This PR lets you change that when using `MetricWriter`.

I'm arguing for the default to be `"\n"` instead of `os.linesep` because:
- [Python has universal new line support](https://peps.python.org/pep-0278/) (so it doesn't care what we do)
- If you're working on a shared analysis and checking in files to version control, you don't want to worry about if you're running on the same OS as your collaborator
- In my experience, more bioinformatics tools have problems with windows line endings than with unix line endings