### PR TITLE
chore(release): bump to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fgpyo"
-version = "1.0.1-dev"
+version = "1.1.0"
 description = "Python bioinformatics and genomics library"
 authors = ["Nils Homer", "Tim Fennell", "Nathan Roach"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,23 @@ homepage = "https://github.com/fulcrumgenomics/fgpyo"
 repository = "https://github.com/fulcrumgenomics/fgpyo"
 keywords = ["bioinformatics"]
 classifiers = [
-	"Development Status :: 3 - Alpha",
+	"Development Status :: 5 - Production/Stable",
 	"Environment :: Console",
 	"Intended Audience :: Developers",
 	"Intended Audience :: Science/Research",
 	"License :: OSI Approved :: MIT License",
+	"Natural Language :: English",
 	"Operating System :: OS Independent",
 	"Programming Language :: Python :: 3",
+	"Programming Language :: Python :: 3.9",
+	"Programming Language :: Python :: 3.10",
+	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
 	"Topic :: Scientific/Engineering :: Bio-Informatics",
 	"Topic :: Software Development :: Documentation",
 	"Topic :: Software Development :: Libraries :: Python Modules",
+	"Typing :: Typed",
 ]
 include = ["LICENSE"]
 


### PR DESCRIPTION
Following the release process here:

- https://github.com/fulcrumgenomics/fgpyo/blob/main/CONTRIBUTING.md#creating-a-release-on-pypi

This release includes the following commits:

- https://github.com/fulcrumgenomics/fgpyo/pull/220
- https://github.com/fulcrumgenomics/fgpyo/pull/183
- https://github.com/fulcrumgenomics/fgpyo/pull/223
- https://github.com/fulcrumgenomics/fgpyo/pull/217
- https://github.com/fulcrumgenomics/fgpyo/pull/226
- https://github.com/fulcrumgenomics/fgpyo/pull/227
- https://github.com/fulcrumgenomics/fgpyo/pull/204