### PR TITLE
Mamba env command to strictly use conda-forge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@
 
 [Poetry][poetry-link] is used to manage the python development environment. 
 
-A simple way to create an environment with the desired version of python and poetry is to use [conda][conda-link].  E.g.:
+A simple way to create an environment with the desired version of python and poetry is to use [mamba][mamba-link].  E.g.:
 
 ```bash
-conda create -n fgpyo -c conda-forge "python>=3.9" poetry
-conda activate fgpyo
+mamba create -n fgpyo -c conda-forge --override-channels "python>=3.9" poetry
+mamba activate fgpyo
 
 # --all-extras is required to install `mkdocs` and associated dependencies,
 # which are required for development 
@@ -17,7 +17,7 @@ poetry install --all-extras
 
 [rtd-link]:    http://fgpyo.readthedocs.org/en/stable
 [poetry-link]: https://github.com/python-poetry/poetry
-[conda-link]:  https://github.com/mamba-org/mamba
+[mamba-link]:  https://github.com/mamba-org/mamba
 
 ## Primary Development Commands
 


### PR DESCRIPTION
Closes #213

Following the guidance here:

- https://mamba.readthedocs.io/en/latest/user_guide/troubleshooting.html#using-the-defaults-channels

P.S. this doesn't fix the known issue that we really shouldn't be using Mamba to install Poetry (it is [ill-advised](https://python-poetry.org/docs/#:~:text=Poetry%20should%20always,running%20poetry%20commands.) to have Poetry in the same env that Poetry will be installing packages into). That issue should be resolved in a separately scoped PR.