### PR TITLE
chore: Update `ci/check.sh` and `CONTRIBUTING.md` to use primary `uv` interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Installation for Local Development
 
-[`uv`][uv-link] is used to manage the python development environment.
+[`uv`][uv-link] is used to manage the Python development environment.
 Follow Astral's [instructions to install `uv`][uv-install-link].
 
 After installing `uv`, create the development environment:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,25 @@
 
 ## Installation for Local Development
 
-[`uv`][uv-link] is used to manage the python development environment; [installation instructions for `uv` are here][uv-install-link].
+[`uv`][uv-link] is used to manage the python development environment.
+Follow Astral's [instructions to install `uv`][uv-install-link].
 
-A simple way to create an environment with the desired version of `python` and `uv` is to use a virtual environment.  E.g.:
+After installing `uv`, create the development environment:
 
 ```console
-uv venv --python 3.12 --seed
-source .venv/bin/activate
-# `--group docs` is required to install `mkdocs` and associated dependencies
-# `--group dev` is required to install test and build dependencies
-uv pip install --group dev --group docs
+uv sync --locked --python 3.12
 ```
 
 [uv-link]:         https://docs.astral.sh/uv/
 [uv-install-link]: https://docs.astral.sh/uv/getting-started/installation/
 
 ## Primary Development Commands
+
+To run all static analysis checks, run:
+
+```console
+./ci/check.sh
+```
 
 To check and resolve linting issues in the codebase, run:
 

--- a/ci/check.sh
+++ b/ci/check.sh
@@ -35,6 +35,13 @@ function run() {
     fi
 }
 
+# Require uv
+if [ ! -x "$(command -v uv)" ]; then
+    echo >&2 "Error: 'uv' not found."
+    echo >&2 "Install via https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+fi
+
 run "Checking lockfile"    "uv lock --check"
 run "Updating environment" "uv sync --locked"
 run "Style Checking"       "uv run ruff format fgpyo tests"

--- a/ci/check.sh
+++ b/ci/check.sh
@@ -35,20 +35,13 @@ function run() {
     fi
 }
 
-if [ ! -f ".venv/bin/activate" ]; then
-    banner "Virtual environment not present in .venv.\nPlease use \`uv venv --python 3.12 --seed\` to create one."
-    exit 1
-fi
-if [ "${VIRTUAL_ENV}" == "" ]; then
-    banner "Virtual environment has not been activated.\nPlease use \`source .venv/bin/activate\` to activate it."
-    exit 1
-fi
-
-run "Style Checking" "uv run ruff format fgpyo tests"
-run "Linting"        "uv run ruff check --fix fgpyo tests"
-run "Type Checking"  "uv run mypy fgpyo tests --config pyproject.toml"
-run "Unit Tests"     "uv run pytest -vv -r sx tests"
-run "Make docs"      "uv run mkdocs build --strict"
+run "Checking lockfile"    "uv lock --check"
+run "Updating environment" "uv sync --locked"
+run "Style Checking"       "uv run ruff format fgpyo tests"
+run "Linting"              "uv run ruff check --fix fgpyo tests"
+run "Type Checking"        "uv run mypy fgpyo tests --config pyproject.toml"
+run "Unit Tests"           "uv run pytest -vv -r sx tests"
+run "Make docs"            "uv run mkdocs build --strict"
 
 if [ -z "$failures" ]; then
     banner "Checks Passed"


### PR DESCRIPTION
## Summary

This PR updates `ci/check.sh` and `CONTRIBUTING.md` to reflect `uv` conventions I've seen in practice.

## Changed

- Removed checks for virtual environments from `ci/check.sh`
- Simplified environment setup instructions