### PR TITLE
Ensure we are using Ubuntu latest in GitHub CI

### DIFF
--- a/.github/workflows/publish_fgpyo.yml
+++ b/.github/workflows/publish_fgpyo.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   on-main-branch-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       on_main: ${{ steps.contains_tag.outputs.retval }}
     steps:
@@ -41,7 +41,7 @@ jobs:
   build-sdist:
     name: build source distribution
     needs: tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,7 +63,7 @@ jobs:
           path: dist/*.tar.gz
 
   publish-to-pypi:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [build-wheels, build-sdist]
     environment: pypi
     permissions:
@@ -82,7 +82,7 @@ jobs:
           verbose: true
 
   make-changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: publish-to-pypi
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
@@ -103,7 +103,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
   make-github-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: github
     permissions:
       contents: write

--- a/.github/workflows/readthedocs.yml
+++ b/.github/workflows/readthedocs.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   documentation-links:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-wheels:
     name: Build wheels for ${{ matrix.python }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
I believe the release process is broken because we've pinned to an older runner and packages are no longer available for that distribution. It should be OK to use `ubuntu-latest` and I generally recommend it.

See broken GitHub Action here:

- https://github.com/fulcrumgenomics/fgpyo/actions/runs/16527405530/job/46744264738