### PR TITLE
feat: `require()`

### DIFF
--- a/fgpyo/__init__.py
+++ b/fgpyo/__init__.py
@@ -1,7 +1,15 @@
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version
 
+from fgpyo._requirements import RequirementError
+from fgpyo._requirements import require
+
 try:
     __version__ = version("fgpyo")
 except PackageNotFoundError:
     __version__ = "dev"  # package is not installed
+
+__all__ = [
+    "require",
+    "RequirementError",
+]

--- a/fgpyo/_requirements.py
+++ b/fgpyo/_requirements.py
@@ -7,18 +7,18 @@ class RequirementError(ValueError):
     """Exception raised when a requirement is not satisfied."""
 
 
-def require(condition: bool, msg: Optional[str] = None) -> None:
+def require(condition: bool, message: Optional[str] = None) -> None:
     """Require a condition be satisfied.
 
     Args:
         condition: The condition to satisfy.
-        msg: An optional message to include with the error when the condition is false.
+        message: An optional message to include with the error when the condition is false.
 
     Raises:
         RequirementError: If the condition is false.
     """
     if not condition:
-        if msg is not None:
-            raise RequirementError(msg)
+        if message is not None:
+            raise RequirementError(message)
         else:
-            raise RequirementError
+            raise RequirementError()

--- a/fgpyo/_requirements.py
+++ b/fgpyo/_requirements.py
@@ -1,0 +1,24 @@
+"""Enforce requirements."""
+
+from typing import Optional
+
+
+class RequirementError(ValueError):
+    """Exception raised when a requirement is not satisfied."""
+
+
+def require(condition: bool, msg: Optional[str] = None) -> None:
+    """Require a condition be satisfied.
+
+    Args:
+        condition: The condition to satisfy.
+        msg: An optional message to include with the error when the condition is false.
+
+    Raises:
+        RequirementError: If the condition is false.
+    """
+    if not condition:
+        if msg is not None:
+            raise RequirementError(msg)
+        else:
+            raise RequirementError

--- a/fgpyo/_requirements.py
+++ b/fgpyo/_requirements.py
@@ -1,24 +1,29 @@
 """Enforce requirements."""
 
-from typing import Optional
+from typing import Callable
+from typing import Union
 
 
 class RequirementError(Exception):
     """Exception raised when a requirement is not satisfied."""
 
 
-def require(condition: bool, message: Optional[str] = None) -> None:
+def require(condition: bool, message: Union[str, Callable[[], str], None] = None) -> None:
     """Require a condition be satisfied.
 
     Args:
         condition: The condition to satisfy.
         message: An optional message to include with the error when the condition is false.
+            The message may be provided as either a string literal or a function returning a string.
+            The function will not be evaluated unless the condition is false.
 
     Raises:
         RequirementError: If the condition is false.
     """
     if not condition:
-        if message is not None:
+        if message is None:
+            raise RequirementError()
+        elif isinstance(message, str):
             raise RequirementError(message)
         else:
-            raise RequirementError()
+            raise RequirementError(message())

--- a/fgpyo/_requirements.py
+++ b/fgpyo/_requirements.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 
-class RequirementError(ValueError):
+class RequirementError(Exception):
     """Exception raised when a requirement is not satisfied."""
 
 

--- a/tests/fgpyo/test_requirements.py
+++ b/tests/fgpyo/test_requirements.py
@@ -1,0 +1,25 @@
+import pytest
+
+from fgpyo import RequirementError
+from fgpyo import require
+
+
+def test_require() -> None:
+    """Require the requirements."""
+    require(True)
+
+
+def test_require_raises() -> None:
+    """Require the requirements."""
+    with pytest.raises(RequirementError) as excinfo:
+        require(False)
+
+    assert str(excinfo.value) == ""
+
+
+def test_require_raises_with_message() -> None:
+    """Require the requirements."""
+    with pytest.raises(RequirementError, match="Message!") as excinfo:
+        require(False, msg="Message!")
+
+    assert str(excinfo.value) == "Message!"

--- a/tests/fgpyo/test_requirements.py
+++ b/tests/fgpyo/test_requirements.py
@@ -20,6 +20,6 @@ def test_require_raises() -> None:
 def test_require_raises_with_message() -> None:
     """Require the requirements."""
     with pytest.raises(RequirementError, match="Message!") as excinfo:
-        require(False, msg="Message!")
+        require(False, message="Message!")
 
     assert str(excinfo.value) == "Message!"

--- a/tests/fgpyo/test_requirements.py
+++ b/tests/fgpyo/test_requirements.py
@@ -23,3 +23,10 @@ def test_require_raises_with_message() -> None:
         require(False, message="Message!")
 
     assert str(excinfo.value) == "Message!"
+
+
+def test_require_raises_with_message_callable() -> None:
+    with pytest.raises(RequirementError, match="Message!") as excinfo:
+        require(False, message=lambda: "Message!")
+
+    assert str(excinfo.value) == "Message!"


### PR DESCRIPTION
## Summary

Closes #132 

I've been using this implementation in a client repo and found it helpful, so thought it would be good to transfer it over.

I do still think the utility presents a possible footgun for coverage checks, since both the happy and unhappy paths share a single line of code, and we may want to consider including a warning in the documentation. 