### PR TITLE
feat: make fastx mismatch name error deterministic

### DIFF
--- a/fgpyo/fastx/__init__.py
+++ b/fgpyo/fastx/__init__.py
@@ -29,8 +29,8 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from types import TracebackType
 from typing import Iterator
+from typing import List
 from typing import Optional
-from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -76,9 +76,9 @@ class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
                 )
             )
         else:
-            record_names: Set[str] = {self._name_minus_ordinal(record.name) for record in records}
-            if len(record_names) != 1:
-                raise ValueError(f"FASTX record names do not all match: {record_names}")
+            record_names: List[str] = [self._name_minus_ordinal(record.name) for record in records]
+            if len(set(record_names)) != 1:
+                raise ValueError(f"FASTX record names do not all match, found: {record_names}")
             return records
 
     def __exit__(

--- a/tests/fgpyo/fastx/test_fastx_zipped.py
+++ b/tests/fgpyo/fastx/test_fastx_zipped.py
@@ -154,12 +154,17 @@ def tests_fastx_zipped_raises_exception_on_mismatched_sequence_names(tmp_path: P
     input.mkdir()
     fasta1 = input / "input1.fasta"
     fasta2 = input / "input2.fasta"
+    fasta3 = input / "input3.fasta"
     fasta1.write_text(">seq1\nAAAA\n")
     fasta2.write_text(">seq2\nCCCC\n")
+    fasta3.write_text(">seq1\nGGGG\n")
 
-    context_manager = FastxZipped(fasta1, fasta2)
+    context_manager = FastxZipped(fasta1, fasta2, fasta3)
     with context_manager as handle:
-        with pytest.raises(ValueError, match=r"FASTX record names do not all match"):
+        with pytest.raises(
+            ValueError,
+            match=r"FASTX record names do not all match, found: \['seq1', 'seq2', 'seq1'\]",
+        ):
             next(handle)
 
     assert all(fastx.closed for fastx in context_manager._fastx)


### PR DESCRIPTION
### Summary:

Motivation: I was working in a project and wanted to test the error raised when read names are mismatched for input reads to `FastxZipped` and found that it was non-deterministic.

Changes:
- feat: updates error message to be deterministic and report all read names in a zipped record if said names are mismatched.

