### PR TITLE
Remove __getitem__ from Cigar

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -607,24 +607,6 @@ class Cigar:
             raise ValueError(f"Cigar {self} has no aligned bases")
         return start_offset, end_offset
 
-    def __getitem__(
-        self, index: Union[int, slice]
-    ) -> Union[CigarElement, Tuple[CigarElement, ...]]:
-        """Returns the cigar element indexed by index
-
-        Arguments:
-            index: int The index of the requested cigar element(s)
-
-        Returns: CigarElement or Tuple[CigarElement,...]
-            The element(s) selected by index
-
-        Throws:
-            TypeError if index isn't an integer or a slice
-            IndexError: if there's no such element
-
-        """
-        return self.elements[index]
-
 
 @enum.unique
 class PairOrientation(enum.Enum):

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -7,34 +7,6 @@ from fgpyo.sam import Cigar
 cigar = Cigar.from_cigarstring("1M4D45N37X23I11=")
 
 
-@pytest.mark.parametrize("index", range(-len(cigar.elements), len(cigar.elements)))
-def test_direct_access(index: int) -> None:
-    assert cigar[index] == cigar.elements[index]
-    assert cigar[index:] == cigar.elements[index:]
-    assert cigar[:index] == cigar.elements[:index]
-    assert cigar[index:-1] == cigar.elements[index:-1]
-
-
-@pytest.mark.parametrize(
-    "index",
-    [
-        -7,
-        -100,
-        6,
-        100,
-    ],
-)
-def test_bad_index_raises_index_error(index: int) -> None:
-    with pytest.raises(IndexError):
-        cigar[index]
-
-
-@pytest.mark.parametrize("index", ["a", "b", (1, 2)])
-def test_bad_index_raises_type_error(index: int) -> None:
-    with pytest.raises(TypeError):
-        cigar[index]
-
-
 @pytest.mark.parametrize(
     ("cigar_string", "expected_range"),
     [


### PR DESCRIPTION
Closes #169 

For the same reasons we concluded `__len__()` is a footgun for Cigar, we also should remove `__getitem__`. A more careful explanation of why is contained in the associated issue.