### PR TITLE
Speed up reverse_complement by using str.translate

### DIFF
--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -90,8 +90,10 @@ def reverse_complement(bases: str) -> str:
     """
     rev_comp = bases.translate(_COMPLEMENTS_TABLE)[::-1]
     if len(rev_comp) != len(bases):
-        # There were invalid characters that weren't translated. Find one and raise KeyError.
-        raise KeyError(next(base for base in bases if base not in _COMPLEMENTS))
+        # There were invalid characters that weren't translated.
+        # Raise KeyError with all the invalid bases.
+        bad_bases = "".join({base for base in bases if base not in _COMPLEMENTS})
+        raise KeyError(f"Invalid bases found: {bad_bases}")
     return rev_comp
 
 


### PR DESCRIPTION
This is the same strategy as used by `biopython`, slightly re-engineered to meet `fgpyo`'s tests (e.g. to fail with `KeyError` if a bad nucleotide is passed). Testing with `%%timeit` shows this to be 10x faster for short sequences (around 100 bp), and 30x faster with long sequences (around 100K bp).

I made the _COMPLEMENTS_TABLE a `tuple` to keep it as `const` as possible.