### PR TITLE
chore(ci): update orhun/git-cliff-action from v3 to v4

### DIFF
--- a/.github/workflows/publish_fgpyo.yml
+++ b/.github/workflows/publish_fgpyo.yml
@@ -94,7 +94,7 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Generate a Changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
           config: pyproject.toml


### PR DESCRIPTION
Releases will fail otherwise.