### PR TITLE
feat(test): add doctest support to pytest

### DIFF
--- a/docs/scripts/strip_doctest_flags.py
+++ b/docs/scripts/strip_doctest_flags.py
@@ -1,0 +1,25 @@
+"""MkDocs hook to strip doctest flags from rendered documentation.
+
+Doctest flags like `# doctest: +SKIP` are useful for controlling doctest execution,
+but they clutter the documentation. This hook removes them from the rendered HTML.
+"""
+
+import re
+from typing import Any
+
+# Pattern to match doctest flags like: # doctest: +SKIP, # doctest: +ELLIPSIS, etc.
+# Also handles multiple flags like: # doctest: +SKIP, +ELLIPSIS
+DOCTEST_FLAG_PATTERN = re.compile(r"\s*#\s*doctest:\s*[+\w,\s]+")
+
+
+def on_page_content(html: str, **kwargs: Any) -> str:
+    """Remove doctest flags from page content.
+
+    Args:
+        html: The rendered HTML content of the page.
+        **kwargs: Additional keyword arguments passed by MkDocs.
+
+    Returns:
+        The HTML content with doctest flags removed.
+    """
+    return DOCTEST_FLAG_PATTERN.sub("", html)

--- a/fgpyo/collections/__init__.py
+++ b/fgpyo/collections/__init__.py
@@ -17,6 +17,7 @@ True
 True
 >>> is_sorted([1, 2, 4, 3])
 False
+
 ```
 
 ## Examples of a "Peekable" Iterator
@@ -34,7 +35,10 @@ An empty peekable iterator throws a
 >>> from fgpyo.collections import PeekableIterator
 >>> piter = PeekableIterator(iter([]))
 >>> piter.peek()
+Traceback (most recent call last):
+    ...
 StopIteration
+
 ```
 
 A peekable iterator will return the next item before consuming it.
@@ -47,6 +51,7 @@ A peekable iterator will return the next item before consuming it.
 1
 >>> [j for j in piter]
 [2, 3]
+
 ```
 
 The [`can_peek()`][fgpyo.collections.PeekableIterator.can_peek] function can be used to determine if
@@ -63,7 +68,10 @@ thrown:
 >>> piter.peek() if piter.can_peek() else -1
 -1
 >>> next(piter)
+Traceback (most recent call last):
+    ...
 StopIteration
+
 ```
 
 [`PeekableIterator`][fgpyo.collections.PeekableIterator]'s constructor supports creation from

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -9,31 +9,39 @@ sequence dictionaries (.dict).
 Writing a FASTA with two contigs each with 100 bases:
 
 ```python
-    >>> from fgpyo.fasta.builder import FastaBuilder
-    >>> builder = FastaBuilder()
-    >>> builder.add("chr10").add("AAAAAAAAAA", 10)
-    >>> builder.add("chr11").add("GGGGGGGGGG", 10)
-    >>> builder.to_file(path = pathlib.Path("test.fasta"))
+>>> from pathlib import Path
+>>> from fgpyo.fasta.builder import FastaBuilder
+>>> builder = FastaBuilder()
+>>> builder.add("chr10").add("AAAAAAAAAA", 10)  # doctest: +ELLIPSIS
+<fgpyo.fasta.builder.ContigBuilder object at ...>
+>>> builder = builder.add("chr11").add("GGGGGGGGGG", 10)
+>>> fasta_path = Path(getfixture("tmp_path")) / "test.fasta"
+>>> builder.to_file(path=fasta_path)  # doctest: +SKIP
+
 ```
 
 Writing a FASTA with one contig with 100 A's and 50 T's:
 
 ```python
-    >>> from fgpyo.fasta.builder import FastaBuilder
-    >>> builder = FastaBuilder()
-    >>> builder.add("chr10").add("AAAAAAAAAA", 10).add("TTTTTTTTTT", 5)
-    >>> builder.to_file(path = pathlib.Path("test.fasta"))
+>>> from fgpyo.fasta.builder import FastaBuilder
+>>> builder = FastaBuilder()
+>>> builder.add("chr10").add("AAAAAAAAAA", 10).add("TTTTTTTTTT", 5)  # doctest: +ELLIPSIS
+<fgpyo.fasta.builder.ContigBuilder object at ...>
+>>> builder.to_file(path=fasta_path)  # doctest: +SKIP
+
 ```
 
 Add bases to existing contig:
 
 ```python
-    >>> from fgpyo.fasta.builder import FastaBuilder
-    >>> builder = FastaBuilder()
-    >>> contig_one = builder.add("chr10").add("AAAAAAAAAA", 1)
-    >>> contig_one.add("NNN", 1)
-    >>> contig_one.bases
-    'AAAAAAAAAANNN'
+>>> from fgpyo.fasta.builder import FastaBuilder
+>>> builder = FastaBuilder()
+>>> contig_one = builder.add("chr10").add("AAAAAAAAAA", 1)
+>>> contig_one.add("NNN", 1)  # doctest: +ELLIPSIS
+<fgpyo.fasta.builder.ContigBuilder object at ...>
+>>> contig_one.bases
+'AAAAAAAAAANNN'
+
 ```
 
 """

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -9,10 +9,9 @@ Building a sequence dictionary from a `pysam.AlignmentHeader`:
 >>> import pysam
 >>> from fgpyo.fasta.sequence_dictionary import SequenceDictionary
 >>> sd: SequenceDictionary
->>> with pysam.AlignmentFile("./fgpyo/sam/tests/data/valid.sam") as fh:
-    ...    sd = SequenceDictionary.from_sam(header=fh.header)
-...
->>> print(sd)
+>>> with pysam.AlignmentFile("./tests/fgpyo/sam/data/valid.sam") as fh:
+...     sd = SequenceDictionary.from_sam(fh.header)
+>>> print(sd)  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101
 @SQ	SN:chr2	LN:101
 @SQ	SN:chr3	LN:101
@@ -21,40 +20,45 @@ Building a sequence dictionary from a `pysam.AlignmentHeader`:
 @SQ	SN:chr6	LN:101
 @SQ	SN:chr7	LN:404
 @SQ	SN:chr8	LN:202
+
 ```
 
 Query based on index:
 
 ```python
->>> print(sd[3])
+>>> print(sd[3])  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr4	LN:101
+
 ```
 
 Query based on name:
 
 ```python
->>> print(sd["chr6"])
+>>> print(sd["chr6"])  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr6	LN:101
+
 ```
 
 Add, get, and delete attributes:
 
 ```python
+>>> from fgpyo.fasta.sequence_dictionary import Keys
 >>> meta = sd[0]
->>> print(meta)
+>>> print(meta)  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101
 >>> meta[Keys.ASSEMBLY] = "hg38"
->>> print(meta))
+>>> print(meta)  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101	AS:hg38
 >>> meta.get(Keys.ASSEMBLY)
-"hg38"
+'hg38'
 >>> meta.get(Keys.SPECIES) is None
 True
 >>> Keys.MD5 in meta
 False
 >>> del meta[Keys.ASSEMBLY]
->>> print(meta)
+>>> print(meta)  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101
+
 ```
 
 Get a sequence based on one of its aliases
@@ -62,7 +66,7 @@ Get a sequence based on one of its aliases
 ```python
 >>> meta[Keys.ALIASES] = "foo,bar,car"
 >>> sd = SequenceDictionary(infos=[meta] + sd.infos[1:])
->>> print(sd)
+>>> print(sd)  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101	AN:foo,bar,car
 @SQ	SN:chr2	LN:101
 @SQ	SN:chr3	LN:101
@@ -71,18 +75,19 @@ Get a sequence based on one of its aliases
 @SQ	SN:chr6	LN:101
 @SQ	SN:chr7	LN:404
 @SQ	SN:chr8	LN:202
->>> print(sd["chr1"])
+>>> print(sd["chr1"])  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101	AN:foo,bar,car
->>> print(sd["bar"])
+>>> print(sd["bar"])  # doctest: +NORMALIZE_WHITESPACE
 @SQ	SN:chr1	LN:101	AN:foo,bar,car
+
 ```
 
 Create a `pysam.AlignmentHeader` from a sequence dictionary:
 
 ```python
->>> sd.to_sam_header()
-<pysam.libcalignmentfile.AlignmentHeader object at 0x10e93f5f0>
->>> print(sd.to_sam_header())
+>>> sd.to_sam_header()  # doctest: +ELLIPSIS
+<pysam.libcalignmentfile.AlignmentHeader object at ...>
+>>> print(sd.to_sam_header())  # doctest: +NORMALIZE_WHITESPACE
 @HD	VN:1.5
 @SQ	SN:chr1	LN:101	AN:foo,bar,car
 @SQ	SN:chr2	LN:101
@@ -92,6 +97,7 @@ Create a `pysam.AlignmentHeader` from a sequence dictionary:
 @SQ	SN:chr6	LN:101
 @SQ	SN:chr7	LN:404
 @SQ	SN:chr8	LN:202
+
 ```
 
 Create a `pysam.AlignmentHeader` from a sequence dictionary with extra header items:
@@ -99,11 +105,11 @@ Create a `pysam.AlignmentHeader` from a sequence dictionary with extra header it
 ```python
 >>> sd.to_sam_header(
 ...     extra_header={"RG": [{"ID": "A", "LB": "a-library"}, {"ID": "B", "LB": "b-library"}]}
-... )
-<pysam.libcalignmentfile.AlignmentHeader object at 0x10e93fe30>
+... )  # doctest: +ELLIPSIS
+<pysam.libcalignmentfile.AlignmentHeader object at ...>
 >>> print(sd.to_sam_header(
 ...     extra_header={"RG": [{"ID": "A", "LB": "a-library"}, {"ID": "B", "LB": "b-library"}]}
-... ))
+... ))  # doctest: +NORMALIZE_WHITESPACE
 @HD	VN:1.5
 @SQ	SN:chr1	LN:101	AN:foo,bar,car
 @SQ	SN:chr2	LN:101
@@ -115,6 +121,7 @@ Create a `pysam.AlignmentHeader` from a sequence dictionary with extra header it
 @SQ	SN:chr8	LN:202
 @RG	ID:A	LB:a-library
 @RG	ID:B	LB:b-library
+
 ```
 """
 

--- a/fgpyo/fastx/__init__.py
+++ b/fgpyo/fastx/__init__.py
@@ -15,12 +15,13 @@ pointer in memory will refer to the most recent record only, and not any past re
 the state of all previously iterated records, set the parameter ``persist`` to `True`.
 
 ```python
-   >>> from fgpyo.fastx import FastxZipped
-   >>> with FastxZipped("r1.fq", "r2.fq", persist=False) as zipped:
-   ...    for (r1, r2) in zipped:
-   ...         print(f"{r1.name}: {r1.sequence}, {r2.name}: {r2.sequence}")
-   seq1: AAAA, seq1: CCCC
-   seq2: GGGG, seq2: TTTT
+>>> from fgpyo.fastx import FastxZipped
+>>> with FastxZipped("r1.fq", "r2.fq", persist=False) as zipped:  # doctest: +SKIP
+...    for (r1, r2) in zipped:
+...         print(f"{r1.name}: {r1.sequence}, {r2.name}: {r2.sequence}")
+seq1: AAAA, seq1: CCCC
+seq2: GGGG, seq2: TTTT
+
 ```
 
 """

--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -14,30 +14,48 @@ The functions in this module make it easy to:
 ## fgpyo.io Examples:
 
 ```python
+>>> import fgpyo.io as fio
+>>> from fgpyo.io import write_lines, read_lines
+>>> from pathlib import Path
 
-    >>> import fgpyo.io as fio
-    >>> from pathlib import Path
-    Assert that a path exists and is readable
-    >>> path_flat: Path = Path("example.txt")
-    >>> path_compressed: Path = Path("example.txt.gz")
-    >>> fio.path_is_readable(path_flat)
-    AssertionError: Cannot read non-existent path: example.txt
-    >>> fio.path_is_readable(compressed_file)
-    AssertionError: Cannot read non-existent path: example.txt.gz
-    Write to and read from path
-    >>> write_lines(path = path_flat, lines_to_write=["flat file", 10])
-    >>> write_lines(path = path_compressed, lines_to_write=["gzip file", 10])
-    Read lines from a path into a generator
-    >>> lines = read_lines(path = path_flat)
-    >>> next(lines)
-    "flat file"
-    >>> next(lines)
-    "10"
-    >>> lines = read_lines(path = path_compressed)
-    >>> next(lines)
-    "gzip file"
-    >>> next(lines)
-    "10"
+```
+
+Assert that a path exists and is readable:
+
+```python
+>>> tmp_dir = Path(getfixture("tmp_path"))
+>>> path_flat: Path = tmp_dir / "example.txt"
+>>> fio.assert_path_is_readable(path_flat)  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+AssertionError: Cannot read non-existent path: ...
+
+```
+
+Write to and read from path:
+
+```python
+>>> path_flat = tmp_dir / "example.txt"
+>>> path_compressed = tmp_dir / "example.txt.gz"
+>>> write_lines(path=path_flat, lines_to_write=["flat file", 10])
+>>> write_lines(path=path_compressed, lines_to_write=["gzip file", 10])
+
+```
+
+Read lines from a path into a generator:
+
+```python
+>>> lines = read_lines(path=path_flat)
+>>> next(lines)
+'flat file'
+>>> next(lines)
+'10'
+>>> lines = read_lines(path=path_compressed)
+>>> next(lines)
+'gzip file'
+>>> next(lines)
+'10'
+
 ```
 
 """
@@ -165,9 +183,10 @@ def to_reader(path: Path, threads: Optional[int] = None) -> TextIOWrapper:
         threads: the number of threads to use when decompressing gzip files
 
     Example:
-        >>> reader = fio.to_reader(path = Path("reader.txt"))
-        >>> reader.readlines()
-        >>> reader.close()
+        >>> import fgpyo.io as fio
+        >>> reader = fio.to_reader(path=Path("reader.txt"))  # doctest: +SKIP
+        >>> reader.readlines()  # doctest: +SKIP
+        >>> reader.close()  # doctest: +SKIP
 
     """
     if path.suffix in COMPRESSED_FILE_EXTENSIONS:
@@ -189,9 +208,10 @@ def to_writer(path: Path, append: bool = False, threads: Optional[int] = None) -
         threads: the number of threads to use when compressing gzip files
 
     Example:
-        >>> writer = fio.to_writer(path = Path("writer.txt"))
-        >>> writer.write(f'{something}\\n')
-        >>> writer.close()
+        >>> import fgpyo.io as fio
+        >>> writer = fio.to_writer(path=Path("writer.txt"))  # doctest: +SKIP
+        >>> writer.write("something\\n")  # doctest: +SKIP
+        >>> writer.close()  # doctest: +SKIP
 
     """
     mode_prefix: str = "a" if append else "w"
@@ -226,7 +246,9 @@ def read_lines(path: Path, strip: bool = False, threads: Optional[int] = None) -
         threads: the number of threads to use when decompressing gzip files
 
     Example:
-        read_back = fio.read_lines(path)
+        >>> import fgpyo.io as fio
+        >>> read_back = fio.read_lines(path)  # doctest: +SKIP
+
     """
     with to_reader(path=path, threads=threads) as reader:
         if strip:

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -15,36 +15,36 @@ See more at: https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures
 ## Examples
 
 ```python
-   >>> from fgpyo.read_structure import ReadStructure
-   >>> rs = ReadStructure.from_string("75T8B75T")
-   >>> [str(segment) for segment in rs]
-   '75T', '8B', '75T'
-   >>> rs[0]
-   ReadSegment(offset=0, length=75, kind=<SegmentType.Template: 'T'>)
-   >>> rs = rs.with_variable_last_segment()
-   >>> [str(segment) for segment in rs]
-   ['75T', '8B', '+T']
-   >>> rs[-1]
-   ReadSegment(offset=83, length=None, kind=<SegmentType.Template: 'T'>)
-   >>> rs = ReadStructure.from_string("1B2M+T")
-   >>> [s.bases for s in rs.extract("A"*6)]
-   ['A', 'AA', 'AAA']
-   >>> [s.bases for s in rs.extract("A"*5)]
-   ['A', 'AA', 'AA']
-   >>> [s.bases for s in rs.extract("A"*4)]
-   ['A', 'AA', 'A']
-   >>> [s.bases for s in rs.extract("A"*3)]
-   ['A', 'AA', '']
-   >>> rs.template_segments()
-   (ReadSegment(offset=3, length=None, kind=<SegmentType.Template: 'T'>),)
-   >>> [str(segment) for segment in rs.template_segments()]
-   ['+T']
-   >>> try:
-   ...   ReadStructure.from_string("23T2TT23T")
-   ... except ValueError as ex:
-   ...   print(str(ex))
-   ...
-   Read structure missing length information: 23T2T[T]23T
+>>> from fgpyo.read_structure import ReadStructure
+>>> rs = ReadStructure.from_string("75T8B75T")
+>>> [str(segment) for segment in rs]
+['75T', '8B', '75T']
+>>> rs[0]
+ReadSegment(offset=0, length=75, kind=<SegmentType.Template: 'T'>)
+>>> rs = rs.with_variable_last_segment()
+>>> [str(segment) for segment in rs]
+['75T', '8B', '+T']
+>>> rs[-1]
+ReadSegment(offset=83, length=None, kind=<SegmentType.Template: 'T'>)
+>>> rs = ReadStructure.from_string("1B2M+T")
+>>> [s.bases for s in rs.extract("A"*6)]
+['A', 'AA', 'AAA']
+>>> [s.bases for s in rs.extract("A"*5)]
+['A', 'AA', 'AA']
+>>> [s.bases for s in rs.extract("A"*4)]
+['A', 'AA', 'A']
+>>> [s.bases for s in rs.extract("A"*3)]
+['A', 'AA', '']
+>>> rs.template_segments()
+(ReadSegment(offset=3, length=None, kind=<SegmentType.Template: 'T'>),)
+>>> [str(segment) for segment in rs.template_segments()]
+['+T']
+>>> try:
+...   ReadStructure.from_string("23T2TT23T")
+... except ValueError as ex:
+...   print(str(ex))
+Read structure missing length information: 23T2T[T]23T
+
 ```
 """
 

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -28,51 +28,55 @@ Opening a SAM/BAM file for reading, auto-recognizing the file-type by the file e
 [`SamFileType()`][fgpyo.sam.SamFileType] for the supported file types.
 
 ```python
-    >>> from fgpyo.sam import reader
-    >>> with reader("/path/to/sample.sam") as fh:
-    ...     for record in fh:
-    ...         print(record.name)  # do something
-    >>> with reader("/path/to/sample.bam") as fh:
-    ...     for record in fh:
-    ...         print(record.name)  # do something
+>>> from fgpyo.sam import reader
+>>> with reader("/path/to/sample.sam") as fh:  # doctest: +SKIP
+...     for record in fh:
+...         print(record.query_name)  # do something
+>>> with reader("/path/to/sample.bam") as fh:  # doctest: +SKIP
+...     for record in fh:
+...         print(record.query_name)  # do something
+
 ```
 
 Opening a SAM/BAM file for reading, explicitly passing the file type.
 
 ```python
-    >>> from fgpyo.sam import SamFileType
-    >>> with reader(path="/path/to/sample.ext1", file_type=SamFileType.SAM) as fh:
-    ...     for record in fh:
-    ...         print(record.name)  # do something
-    >>> with reader(path="/path/to/sample.ext2", file_type=SamFileType.BAM) as fh:
-    ...     for record in fh:
-    ...         print(record.name)  # do something
+>>> from fgpyo.sam import SamFileType
+>>> with reader(path="/path/to/sample.ext1", file_type=SamFileType.SAM) as fh:  # doctest: +SKIP
+...     for record in fh:
+...         print(record.query_name)  # do something
+>>> with reader(path="/path/to/sample.ext2", file_type=SamFileType.BAM) as fh:  # doctest: +SKIP
+...     for record in fh:
+...         print(record.query_name)  # do something
+
 ```
 
 Opening a SAM/BAM file for reading, using an existing file-like object
 
 ```python
-    >>> with open("/path/to/sample.sam", "rb") as file_object:
-    ...     with reader(path=file_object, file_type=SamFileType.BAM) as fh:
-    ...         for record in fh:
-    ...             print(record.name)  # do something
+>>> with open("/path/to/sample.sam", "rb") as file_object:  # doctest: +SKIP
+...     with reader(path=file_object, file_type=SamFileType.BAM) as fh:
+...         for record in fh:
+...             print(record.query_name)  # do something
+
 ```
 
 Opening a SAM/BAM file for writing follows similar to the [`reader()`][fgpyo.sam.reader]
 method, but the SAM file header object is required.
 
 ```python
-    >>> from fgpyo.sam import writer
-    >>> header: Dict[str, Any] = {
-    ...     "HD": {"VN": "1.5", "SO": "coordinate"},
-    ...     "RG": [{"ID": "1", "SM": "1_AAAAAA", "LB": "lib", "PL": "ILLUMINA", "PU": "xxx.1"}],
-    ...     "SQ":  [
-    ...         {"SN": "chr1", "LN": 249250621},
-    ...         {"SN": "chr2", "LN": 243199373}
-    ...     ]
-    ... }
-    >>> with writer(path="/path/to/sample.bam", header=header) as fh:
-    ...     pass  # do something
+>>> from fgpyo.sam import writer
+>>> header: Dict[str, Any] = {
+...     "HD": {"VN": "1.5", "SO": "coordinate"},
+...     "RG": [{"ID": "1", "SM": "1_AAAAAA", "LB": "lib", "PL": "ILLUMINA", "PU": "xxx.1"}],
+...     "SQ":  [
+...         {"SN": "chr1", "LN": 249250621},
+...         {"SN": "chr2", "LN": 243199373}
+...     ]
+... }  # doctest: +SKIP
+>>> with writer(path="/path/to/sample.bam", header=header) as fh:  # doctest: +SKIP
+...     pass  # do something
+
 ```
 
 ## Examples of Manipulating Cigars
@@ -80,28 +84,33 @@ method, but the SAM file header object is required.
 Creating a [`Cigar` from a `pysam.AlignedSegment`][fgpyo.sam.Cigar].
 
 ```python
-    >>> from fgpyo.sam import Cigar
-    >>> with reader("/path/to/sample.sam") as fh:
-    ...     record = next(fh)
-    ...     cigar = Cigar.from_cigartuples(record.cigartuples)
-    ...     print(str(cigar))
-    50M2D5M10S
+>>> from fgpyo.sam import Cigar
+>>> with reader("/path/to/sample.sam") as fh:  # doctest: +SKIP
+...     record = next(fh)
+...     cigar = Cigar.from_cigartuples(record.cigartuples)
+...     print(str(cigar))
+50M2D5M10S
+
 ```
 
 Creating a [`Cigar` from a `str()`][fgpyo.sam.Cigar].
 
 ```python
-    >>> cigar = Cigar.from_cigarstring("50M2D5M10S")
-    >>> print(str(cigar))
-    50M2D5M10S
+>>> cigar = Cigar.from_cigarstring("50M2D5M10S")
+>>> print(str(cigar))
+50M2D5M10S
+
 ```
 
 If the cigar string is invalid, the exception message will show you the problem character(s) in
 square brackets.
 
 ```python
-    >>> cigar = Cigar.from_cigarstring("10M5U")
-    ... CigarException("Malformed cigar: 10M5[U]")
+>>> cigar = Cigar.from_cigarstring("10M5U")
+Traceback (most recent call last):
+    ...
+fgpyo.sam.CigarParsingException: Malformed cigar: 10M5[U]
+
 ```
 
 The cigar contains a tuple of [`CigarElement()`][fgpyo.sam.CigarElement]s.  Each element
@@ -112,46 +121,51 @@ The number of bases aligned on the query (i.e. the number of bases consumed by t
 the query):
 
 ```python
-    >>> cigar = Cigar.from_cigarstring("50M2D5M2I10S")
-    >>> [e.length_on_query for e in cigar.elements]
-    [50, 0, 5, 2, 10]
-    >>> [e.length_on_target for e in cigar.elements]
-    [50, 2, 5, 0, 0]
-    >>> [e.operator.is_indel for e in cigar.elements]
-    [False, True, False, True, False]
+>>> cigar = Cigar.from_cigarstring("50M2D5M2I10S")
+>>> [e.length_on_query for e in cigar.elements]
+[50, 0, 5, 2, 10]
+>>> [e.length_on_target for e in cigar.elements]
+[50, 2, 5, 0, 0]
+>>> [e.operator.is_indel for e in cigar.elements]
+[False, True, False, True, False]
+
 ```
 
-Any particular tuple can be accessed directly with its index (and works with negative indexes
-and slices):
+Any particular element can be accessed directly via `.elements` with its index (and works with
+negative indexes and slices):
 
-    >>> cigar = Cigar.from_cigarstring("50M2D5M2I10S")
-    >>> cigar[0].length
-    50
-    >>> cigar[1].operator
-    <CigarOp.D: (2, 'D', False, True)>
-    >>> cigar[-1].operator
-    <CigarOp.S: (4, 'S', True, False)>
-    >>> tuple(x.operator.character for x in cigar[1:3])
-    ('D','M')
-    >>> tuple(x.operator.character for x in cigar[-2:])
-    ('I', 'S')
+```python
+>>> cigar = Cigar.from_cigarstring("50M2D5M2I10S")
+>>> cigar.elements[0].length
+50
+>>> cigar.elements[1].operator
+<CigarOp.D: (2, 'D', False, True)>
+>>> cigar.elements[-1].operator
+<CigarOp.S: (4, 'S', True, False)>
+>>> tuple(x.operator.character for x in cigar.elements[1:3])
+('D', 'M')
+>>> tuple(x.operator.character for x in cigar.elements[-2:])
+('I', 'S')
+
+```
 
 ## Examples of parsing the SA tag and individual supplementary alignments
 
 ```python
-   >>> from fgpyo.sam import SupplementaryAlignment
-   >>> sup = SupplementaryAlignment.parse("chr1,123,+,50S100M,60,0")
-   >>> sup.reference_name
-   'chr1
-   >>> sup.nm
-   0
-   >>> from typing import List
-   >>> sa_tag = "chr1,123,+,50S100M,60,0;chr2,456,-,75S75M,60,1"
-   >>> sups: List[SupplementaryAlignment] = SupplementaryAlignment.parse_sa_tag(tag=sa_tag)
-   >>> len(sups)
-   2
-   >>> [str(sup.cigar) for sup in sups]
-   ['50S100M', '75S75M']
+>>> from fgpyo.sam import SupplementaryAlignment
+>>> sup = SupplementaryAlignment.parse("chr1,123,+,50S100M,60,0")
+>>> sup.reference_name
+'chr1'
+>>> sup.nm
+0
+>>> from typing import List
+>>> sa_tag = "chr1,123,+,50S100M,60,0;chr2,456,-,75S75M,60,1"
+>>> sups: List[SupplementaryAlignment] = SupplementaryAlignment.parse_sa_tag(tag=sa_tag)
+>>> len(sups)
+2
+>>> [str(sup.cigar) for sup in sups]
+['50S100M', '75S75M']
+
 ```
 """
 

--- a/fgpyo/sam/clipping.py
+++ b/fgpyo/sam/clipping.py
@@ -23,11 +23,22 @@ Upon clipping a set of additional SAM tags are removed from reads as they are li
 For example, to clip the last 10 query bases of all records and reduce the qualities to Q2:
 
 ```python
-    >>> from fgpyo.sam import reader, clipping
-    >>> with reader("/path/to/sample.sam") as fh:
-    ...     for rec in fh:
-    ...         clipping.softclip_end_of_alignment_by_query(rec, 10, 2)
-    ...         print(rec.cigarstring)
+>>> from fgpyo.sam import reader, clipping
+>>> with reader("./tests/fgpyo/sam/data/valid.sam") as fh:
+...     for rec in fh:
+...         before = rec.cigarstring
+...         info = clipping.softclip_end_of_alignment_by_query(rec, 10, 2)
+...         after = rec.cigarstring
+...         print(f"before: {before} after: {after} info: {info}")
+before: 101M after: 91M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: 101M after: 91M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: 101M after: 91M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: 101M after: 91M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: 101M after: 91M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: 101M after: 91M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: 10M1D10M5I76M after: 10M1D10M5I66M10S info: ClippingInfo(query_bases_clipped=10, ref_bases_clipped=10)
+before: None after: None info: ClippingInfo(query_bases_clipped=0, ref_bases_clipped=0)
+
 ```
 
 It should be noted that any clipping potentially makes the common SAM tags NM, MD and UQ
@@ -36,13 +47,13 @@ of an alignment changes the position (reference_start) of the record. Any reads 
 aligned bases after clipping are set to be unmapped.  If writing the clipped reads back to a BAM
 it should be noted that:
 
-    - Mate pairs may have incorrect information about their mate's positions
-    - Even if the input was coordinate sorted, the output may be out of order
+- Mate pairs may have incorrect information about their mate's positions
+- Even if the input was coordinate sorted, the output may be out of order
 
 To rectify these problems it is necessary to do the equivalent of:
 
 ```console
-    cat clipped.bam | samtools sort -n | samtools fixmate | samtools sort | samtools calmd
+cat clipped.bam | samtools sort -n | samtools fixmate | samtools sort | samtools calmd
 ```
 """  # noqa: E501
 

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -10,24 +10,25 @@ fixed number of records.  Logging can be written to `logging.Logger` as well as 
 method.
 
 ```python
-   >>> from fgpyo.util.logging import ProgressLogger
-   >>> logged_lines = []
-   >>> progress = ProgressLogger(
-   ...     printer=lambda s: logged_lines.append(s),
-   ...     verb="recorded",
-   ...     noun="items",
-   ...     unit=2
-   ... )
-   >>> progress.record(reference_name="chr1", position=1)  # does not log
-   False
-   >>> progress.record(reference_name="chr1", position=2)  # logs
-   True
-   >>> progress.record(reference_name="chr1", position=3)  # does not log
-   False
-   >>> progress.log_last()  # will log the last recorded item, if not previously logged
-   True
-   >>> logged_lines  # show the lines logged
-   ['recorded 2 items: chr1:2', 'recorded 3 items: chr1:3']
+>>> from fgpyo.util.logging import ProgressLogger
+>>> logged_lines = []
+>>> progress = ProgressLogger(
+...     printer=lambda s: logged_lines.append(s),
+...     verb="recorded",
+...     noun="items",
+...     unit=2
+... )
+>>> progress.record(reference_name="chr1", position=1)  # does not log
+False
+>>> progress.record(reference_name="chr1", position=2)  # logs
+True
+>>> progress.record(reference_name="chr1", position=3)  # does not log
+False
+>>> progress.log_last()  # will log the last recorded item, if not previously logged
+True
+>>> logged_lines  # show the lines logged
+['recorded 2 items: chr1:2', 'recorded 3 items: chr1:3']
+
 ```
 """
 

--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -19,33 +19,36 @@ Variants are added with the [`add()`][fgpyo.vcf.builder.VariantBuilder.add] meth
 which returns a `pysam.VariantRecord`.
 
 ```python
-    >>> import pysam
-    >>> from fgpyo.vcf.builder import VariantBuilder
-    >>> builder: VariantBuilder = VariantBuilder()
-    >>> new_record_1: pysam.VariantRecord = builder.add()  # uses the defaults
-    >>> new_record_2: pysam.VariantRecord = builder.add(
-    >>>     contig="chr2", pos=1001, id="rs1234", ref="C", alts=["T"],
-    >>>     qual=40, filter=["PASS"]
-    >>> )
+>>> import pysam
+>>> from fgpyo.vcf.builder import VariantBuilder
+>>> builder: VariantBuilder = VariantBuilder()
+>>> new_record_1: pysam.VariantRecord = builder.add()  # uses the defaults
+>>> new_record_2: pysam.VariantRecord = builder.add(
+...     contig="chr2", pos=1001, id="rs1234", ref="C", alts=["T"],
+...     qual=40, filter=["PASS"]
+... )
+
 ```
 
 VariantBuilder can create sites-only, single-sample, or multi-sample VCF files. If not producing a
 sites-only VCF file, VariantBuilder must be created by passing a list of sample IDs
 
 ```python
-    >>> builder: VariantBuilder = VariantBuilder(sample_ids=["sample1", "sample2"])
-    >>> new_record_1: pysam.VariantRecord = builder.add()  # uses the defaults
-    >>> new_record_2: pysam.VariantRecord = builder.add(
-    >>>     samples={"sample1": {"GT": "0|1"}, "sample2": {"GT": "0|0"}}
-    >>> )
+>>> builder: VariantBuilder = VariantBuilder(sample_ids=["sample1", "sample2"])
+>>> new_record_1: pysam.VariantRecord = builder.add()  # uses the defaults
+>>> new_record_2: pysam.VariantRecord = builder.add(
+...     samples={"sample1": {"GT": "0|1"}, "sample2": {"GT": "0|0"}}
+... )
+
 ```
 
 The variants stored in the builder can be retrieved as a coordinate sorted VCF file via the
 [`to_path()`][fgpyo.vcf.builder.VariantBuilder.to_path] method:
 
 ```python
-    >>>     from pathlib import Path
-    >>>     path_to_vcf: Path = builder.to_path()
+>>> from pathlib import Path
+>>> path_to_vcf: Path = builder.to_path()  # doctest: +SKIP
+
 ```
 
 The variants may also be retrieved in the order they were added via the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,8 @@ theme:
   include_sidebar: true
   collapse_navigation: false
 repo_url: https://github.com/fulcrumgenomics/fgpyo
+hooks:
+  - docs/scripts/strip_doctest_flags.py
 plugins:
   - autorefs:
       resolve_closest: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "mypy==1.18.2",
     "pytest>=7.4.0",
     "pytest-cov>=2.8.1",
+    "pytest-doctestplus>=1.0.0",
     "ruff==0.13.2",
     "setuptools>=68.0.0",
     "poethepoet ~=0.37",
@@ -123,8 +124,11 @@ addopts    = [
     "-r=sx",
     "--color=yes",
     "--import-mode=importlib",
-    "--cov"
+    "--cov",
+    "--doctest-plus",
 ]
+doctest_plus = "enabled"
+doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 
 [tool.poe.tasks]
 fix-format = "ruff format"
@@ -136,11 +140,12 @@ fix-all.sequence    = [
     "fix-lint"
 ]
 
-check-lock   = "uv lock --check"
-check-format = "ruff format --check --diff"
-check-lint   = "ruff check"
-check-tests  = "pytest"
-check-typing = "mypy"
+check-lock     = "uv lock --check"
+check-format   = "ruff format --check --diff"
+check-lint     = "ruff check"
+check-tests    = "pytest"
+check-doctests = "pytest --doctest-plus --doctest-only fgpyo"
+check-typing   = "mypy"
 
 check-all.ignore_fail = "return_non_zero"
 check-all.sequence    = [
@@ -148,7 +153,8 @@ check-all.sequence    = [
     "check-format",
     "check-lint",
     "check-typing",
-    "check-tests"
+    "check-tests",
+    "check-doctests"
 ]
 
 fix-and-check-all.ignore_fail = "return_non_zero"
@@ -157,7 +163,8 @@ fix-and-check-all.sequence    = [
     "fix-format",
     "fix-lint",
     "check-typing",
-    "check-tests"
+    "check-tests",
+    "check-doctests"
 ]
 
 build-docs = "mkdocs build --strict"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9.0, <4.0"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -253,6 +253,7 @@ dev = [
     { name = "poethepoet" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-doctestplus" },
     { name = "ruff" },
     { name = "setuptools" },
 ]
@@ -285,6 +286,7 @@ dev = [
     { name = "poethepoet", specifier = "~=0.37" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-cov", specifier = ">=2.8.1" },
+    { name = "pytest-doctestplus", specifier = ">=1.0.0" },
     { name = "ruff", specifier = "==0.13.2" },
     { name = "setuptools", specifier = ">=68.0.0" },
 ]
@@ -946,6 +948,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945, upload-time = "2024-10-29T20:13:35.363Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949, upload-time = "2024-10-29T20:13:33.215Z" },
+]
+
+[[package]]
+name = "pytest-doctestplus"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ad/896366e91c0b039d1f2d840a821d70aff18e97423188d1d244a9fb1254ae/pytest_doctestplus-1.6.0.tar.gz", hash = "sha256:f893d68370d19b418d58da0047d36a4feedac7ed28bc236858f484e994f1ac66", size = 50186, upload-time = "2025-11-20T10:17:17.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/1c/ff1548922bad1f0fc6003567ab7872a70a6e3523b7a3ea331b6fb0ca40ff/pytest_doctestplus-1.6.0-py3-none-any.whl", hash = "sha256:7ea003abfd62a787fee4cae674b0efc77c2fb73518ae60da662dc3b3ec2a47ed", size = 25687, upload-time = "2025-11-20T10:17:15.908Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #161.

Adds pytest-doctestplus and fixes docstrings for doctest compatibility. Also adds a mkdocs hook to strip doctest flags from rendered docs.

<!-- readthedocs-preview fgpyo start -->
----
📚 Documentation preview 📚: https://fgpyo--268.org.readthedocs.build/en/268/

<!-- readthedocs-preview fgpyo end -->