### PR TITLE
chore: Modernize ruff config

### DIFF
--- a/docs/scripts/strip_doctest_flags.py
+++ b/docs/scripts/strip_doctest_flags.py
@@ -13,7 +13,7 @@ from typing import Any
 DOCTEST_FLAG_PATTERN = re.compile(r"\s*#\s*doctest:\s*[+\w,\s]+")
 
 
-def on_page_content(html: str, **kwargs: Any) -> str:
+def on_page_content(html: str, **_kwargs: Any) -> str:
     """
     Remove doctest flags from page content.
 

--- a/docs/scripts/strip_doctest_flags.py
+++ b/docs/scripts/strip_doctest_flags.py
@@ -1,4 +1,5 @@
-"""MkDocs hook to strip doctest flags from rendered documentation.
+"""
+MkDocs hook to strip doctest flags from rendered documentation.
 
 Doctest flags like `# doctest: +SKIP` are useful for controlling doctest execution,
 but they clutter the documentation. This hook removes them from the rendered HTML.
@@ -13,7 +14,8 @@ DOCTEST_FLAG_PATTERN = re.compile(r"\s*#\s*doctest:\s*[+\w,\s]+")
 
 
 def on_page_content(html: str, **kwargs: Any) -> str:
-    """Remove doctest flags from page content.
+    """
+    Remove doctest flags from page content.
 
     Args:
         html: The rendered HTML content of the page.

--- a/fgpyo/_requirements.py
+++ b/fgpyo/_requirements.py
@@ -8,7 +8,8 @@ class RequirementError(Exception):
 
 
 def require(condition: bool, message: str | Callable[[], str] | None = None) -> None:
-    """Require a condition be satisfied.
+    """
+    Require a condition be satisfied.
 
     Args:
         condition: The condition to satisfy.

--- a/fgpyo/collections/__init__.py
+++ b/fgpyo/collections/__init__.py
@@ -1,5 +1,5 @@
 """
-# Custom Collections and Collection Functions
+# Custom Collections and Collection Functions.
 
 This module contains classes and functions for working with collections and iterators.
 

--- a/fgpyo/collections/__init__.py
+++ b/fgpyo/collections/__init__.py
@@ -103,7 +103,8 @@ LessThanOrEqualType = TypeVar("LessThanOrEqualType", bound=SupportsLessThanOrEqu
 
 
 class PeekableIterator(Generic[IterType], Iterator[IterType]):
-    """A peekable iterator wrapping an iterator or iterable.
+    """
+    A peekable iterator wrapping an iterator or iterable.
 
     This allows returning the next item without consuming it.
 
@@ -139,7 +140,8 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
             raise StopIteration
 
     def takewhile(self, pred: Callable[[IterType], bool]) -> List[IterType]:
-        """Consumes from the iterator while pred is true, and returns the result as a List.
+        """
+        Consumes from the iterator while pred is true, and returns the result as a List.
 
         The iterator is left pointing at the first non-matching item, or if all items match
         then the iterator will be exhausted.
@@ -158,7 +160,8 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
         return xs
 
     def dropwhile(self, pred: Callable[[IterType], bool]) -> "PeekableIterator[IterType]":
-        """Drops elements from the iterator while the predicate is true.
+        """
+        Drops elements from the iterator while the predicate is true.
 
         Updates the iterator to point at the first non-matching element, or exhausts the
         iterator if all elements match the predicate.
@@ -176,7 +179,8 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
 
 
 def is_sorted(iterable: Iterable[LessThanOrEqualType]) -> bool:
-    """Tests lazily if an iterable of comparable objects is sorted or not.
+    """
+    Tests lazily if an iterable of comparable objects is sorted or not.
 
     Args:
         iterable: An iterable of comparable objects.

--- a/fgpyo/collections/__init__.py
+++ b/fgpyo/collections/__init__.py
@@ -113,6 +113,7 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
     """
 
     def __init__(self, source: Iterator[IterType] | Iterable[IterType]) -> None:
+        """Initializes the PeekableIterator with the given source."""
         self._iter: Iterator[IterType] = iter(source)
         self._sentinel: Any = object()
         self.__update_peek()

--- a/fgpyo/collections/__init__.py
+++ b/fgpyo/collections/__init__.py
@@ -93,7 +93,9 @@ from typing import TypeVar
 class SupportsLessThanOrEqual(Protocol):
     """A structural type for objects that support less-than-or-equal comparison."""
 
-    def __le__(self, other: Any) -> bool: ...
+    def __le__(self, other: Any) -> bool:
+        """Return True if self is less than or equal to other."""
+        ...
 
 
 IterType = TypeVar("IterType")
@@ -119,9 +121,11 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
         self.__update_peek()
 
     def __iter__(self) -> Iterator[IterType]:
+        """Returns self as the iterator."""
         return self
 
     def __next__(self) -> IterType:
+        """Returns the next item and advances the iterator."""
         to_return = self.peek()
         self.__update_peek()
         return to_return

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -1,5 +1,5 @@
 """
-# Classes for generating fasta files and records for testing
+# Classes for generating fasta files and records for testing.
 
 This module contains utility classes for creating fasta files, indexed fasta files (.fai), and
 sequence dictionaries (.dict).
@@ -74,7 +74,7 @@ else:
 
 def pysam_dict(assembly: str, species: str, output_path: str, input_path: str) -> None:
     """
-    Calls pysam.dict and writes the sequence dictionary to the provided output path
+    Calls pysam.dict and writes the sequence dictionary to the provided output path.
 
     Args:
         assembly: Assembly
@@ -87,7 +87,7 @@ def pysam_dict(assembly: str, species: str, output_path: str, input_path: str) -
 
 def pysam_faidx(input_path: str) -> None:
     """
-    Calls pysam.faidx and writes fasta index in the same file location as the fasta file
+    Calls pysam.faidx and writes fasta index in the same file location as the fasta file.
 
     Args:
         input_path: Path to fasta file
@@ -179,7 +179,7 @@ class FastaBuilder:
         self.__contig_builders: Dict[str, ContigBuilder] = {}
 
     def __getitem__(self, key: str) -> ContigBuilder:
-        """Access instance of ContigBuilder by name"""
+        """Access instance of ContigBuilder by name."""
         return self.__contig_builders[key]
 
     def add(

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -73,9 +73,10 @@ else:
 
 
 def pysam_dict(assembly: str, species: str, output_path: str, input_path: str) -> None:
-    """Calls pysam.dict and writes the sequence dictionary to the provided output path
+    """
+    Calls pysam.dict and writes the sequence dictionary to the provided output path
 
-    Args
+    Args:
         assembly: Assembly
         species: Species
         output_path: File path to write dictionary to
@@ -85,16 +86,18 @@ def pysam_dict(assembly: str, species: str, output_path: str, input_path: str) -
 
 
 def pysam_faidx(input_path: str) -> None:
-    """Calls pysam.faidx and writes fasta index in the same file location as the fasta file
+    """
+    Calls pysam.faidx and writes fasta index in the same file location as the fasta file
 
-    Args
+    Args:
         input_path: Path to fasta file
     """
     samtools_faidx(input_path)
 
 
 class ContigBuilder:
-    """Builder for constructing new contigs, and adding bases to existing contigs.
+    """
+    Builder for constructing new contigs, and adding bases to existing contigs.
     Existing contigs cannot be overwritten, each contig name in FastaBuilder must
     be unique. Instances of ContigBuilders should be created using FastaBuilder.add(),
     where species and assembly are optional parameters and will defualt to
@@ -127,7 +130,7 @@ class ContigBuilder:
             bases: The bases to be added to the contig
             times: The number of times the bases should be repeated
 
-        Example
+        Example:
         add("AAA", 2) results in the following bases -> "AAAAAA"
         """
         # Remove any spaces in string and enforce upper case format
@@ -137,7 +140,8 @@ class ContigBuilder:
 
 
 class FastaBuilder:
-    """Builder for constructing sets of one or more contigs.
+    """
+    Builder for constructing sets of one or more contigs.
 
     Provides the ability to manufacture sets of contigs from minimal input, and automatically
     generates the information necessary for writing the FASTA file, index, and dictionary.

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -62,10 +62,10 @@ from fgpyo.io import assert_path_is_writable
 if TYPE_CHECKING:
 
     def samtools_dict(*args: Any) -> None:
-        pass
+        """Stub for pysam.dict used under TYPE_CHECKING."""
 
     def samtools_faidx(*args: Any) -> None:
-        pass
+        """Stub for pysam.faidx used under TYPE_CHECKING."""
 
 else:
     from pysam import dict as samtools_dict

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -98,6 +98,7 @@ def pysam_faidx(input_path: str) -> None:
 class ContigBuilder:
     """
     Builder for constructing new contigs, and adding bases to existing contigs.
+
     Existing contigs cannot be overwritten, each contig name in FastaBuilder must
     be unique. Instances of ContigBuilders should be created using FastaBuilder.add(),
     where species and assembly are optional parameters and will defualt to
@@ -192,6 +193,7 @@ class FastaBuilder:
     ) -> ContigBuilder:
         """
         Creates and returns a new ContigBuilder for a contig with the provided name.
+
         Contig names must be unique, attempting to create two seperate contigs with the same
         name will result in an error.
 
@@ -219,6 +221,7 @@ class FastaBuilder:
     ) -> None:
         """
         Writes out the set of accumulated contigs to a FASTA file at the `path` given.
+
         Also generates the accompanying fasta index file (`.fa.fai`) and sequence
         dictionary file (`.dict`).
 

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -117,6 +117,7 @@ class ContigBuilder:
         assembly: str,
         species: str,
     ):
+        """Initializes a ContigBuilder with the given name, assembly, and species."""
         self.name = name
         self.assembly = assembly
         self.species = species
@@ -173,6 +174,7 @@ class FastaBuilder:
         species: str = "testspecies",
         line_length: int = 80,
     ):
+        """Initializes a FastaBuilder with the given assembly, species, and line length."""
         self.assembly: str = assembly
         self.species: str = species
         self.line_length: int = line_length

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -561,7 +561,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
 
     def by_index(self, index: int) -> SequenceMetadata:
         """
-        Gets a `SequenceMetadata` explicitly by `name`.  
+        Gets a `SequenceMetadata` explicitly by `name`.
 
         Raises:
             IndexError: if the index is out of bounds.

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -296,26 +296,32 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     @property
     def md5(self) -> str | None:
+        """Returns the MD5 checksum of the sequence, or None."""
         return self.get(Keys.MD5)
 
     @property
     def assembly(self) -> str | None:
+        """Returns the assembly name, or None."""
         return self.get(Keys.ASSEMBLY)
 
     @property
     def uri(self) -> str | None:
+        """Returns the URI of the sequence, or None."""
         return self.get(Keys.URI)
 
     @property
     def species(self) -> str | None:
+        """Returns the species name, or None."""
         return self.get(Keys.SPECIES)
 
     @property
     def description(self) -> str | None:
+        """Returns the description, or None."""
         return self.get(Keys.DESCRIPTION)
 
     @property
     def topology(self) -> Topology | None:
+        """Returns the topology (linear or circular), or None."""
         value = self.get(Keys.TOPOLOGY)
         return None if value is None else Topology[value]
 

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -179,8 +179,9 @@ class Keys(StrEnum):
     @staticmethod
     def attributes() -> List[str]:
         """
-        The list of keys that are allowed to be attributes in `SequenceMetadata`.  Notably
-        `SEQUENCE_LENGTH` and `SEQUENCE_NAME` are not allowed.
+        The list of keys that are allowed to be attributes in `SequenceMetadata`.
+
+        Notably, `SEQUENCE_LENGTH` and `SEQUENCE_NAME` are not allowed.
         """
         return [key for key in Keys if key != Keys.SEQUENCE_NAME and key != Keys.SEQUENCE_LENGTH]
 
@@ -327,8 +328,10 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     def same_as(self, other: "SequenceMetadata") -> bool:
         """
-        Returns true if the sequences share a common reference name (including aliases), have
-        the same length, and the same MD5 if both have MD5s.
+        Returns True if the two sequences are the same.
+
+        Sequences are considered the same if they share a common reference name (including aliases),
+        have the same length, and have the same MD5 (if both have MD5s).
         """
         if self.length != other.length:
             return False
@@ -343,8 +346,10 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     def to_sam(self) -> Dict[str, Any]:
         """
-        Converts the sequence metadata to a dictionary equivalent to one item in the
-        list of sequences from `pysam.AlignmentHeader#to_dict()["SQ"]`.
+        Converts the sequence metadata to a SAM-formatted dictionary.
+
+        Equivalent to one item in the list of sequences from
+        `pysam.AlignmentHeader#to_dict()["SQ"]`.
         """
         meta_dict: Dict[str, Any] = {
             f"{Keys.SEQUENCE_NAME}": self.name,
@@ -358,9 +363,11 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
     @staticmethod
     def from_sam(meta: Dict[Keys | str, Any], index: int) -> "SequenceMetadata":
         """
-        Builds a `SequenceMetadata` from a dictionary.  The keys must include the sequence
-        name (`Keys.SEQUENCE_NAME`) and length (`Keys.SEQUENCE_LENGTH`).  All other keys from
-        `Keys` will be stored in the resulting attributes.
+        Builds a `SequenceMetadata` from a dictionary.
+
+        The keys must include the sequence name (`Keys.SEQUENCE_NAME`) and length
+        (`Keys.SEQUENCE_LENGTH`). All other keys from `Keys` will be stored in the resulting
+        attributes.
 
         Args:
             meta: the python dictionary with keys from `Keys`.  This is typically the dictionary
@@ -450,8 +457,10 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
 
     def same_as(self, other: "SequenceDictionary") -> bool:
         """
-        Returns true if the sequences share a common reference name (including aliases), have
-        the same length, and the same MD5 if both have MD5s.
+        Returns True if all sequences in the two dictionaries are the same.
+
+        Sequences are considered the same if they share a common reference name (including
+        aliases), have the same length, and have the same MD5 (if both have MD5s).
         """
         if len(self) != len(other):
             return False
@@ -538,8 +547,11 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
 
     def get_by_name(self, name: str) -> SequenceMetadata | None:
         """
-        Gets a `SequenceMetadata` explicitly by `name`.  Returns None if
-        the name does not exist in this dictionary.
+        Gets a `SequenceMetadata` explicitly by `name`.
+
+        Returns:
+            The corresponding SequenceMetadata.
+            None if the name does not exist in this dictionary.
         """
         return self._dict.get(name)
 
@@ -549,8 +561,10 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
 
     def by_index(self, index: int) -> SequenceMetadata:
         """
-        Gets a `SequenceMetadata` explicitly by `name`.  Raises an `IndexError`
-        if the index is out of bounds.
+        Gets a `SequenceMetadata` explicitly by `name`.  
+
+        Raises:
+            IndexError: if the index is out of bounds.
         """
         return self.infos[index]
 

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -155,7 +155,7 @@ import pysam
 
 @unique
 class Topology(StrEnum):
-    """Enumeration for the topology of reference sequences (SAM @SQ.TP)"""
+    """Enumeration for the topology of reference sequences (SAM @SQ.TP)."""
 
     LINEAR = "LINEAR"
     CIRCULAR = "CIRCULAR"
@@ -187,14 +187,14 @@ class Keys(StrEnum):
 
 @dataclass(frozen=True, init=True)
 class AlternateLocus:
-    """Stores an alternate locus for an associated sequence (1-based inclusive)"""
+    """Stores an alternate locus for an associated sequence (1-based inclusive)."""
 
     name: str
     start: int
     end: int
 
     def __post_init__(self) -> None:
-        """Any post initialization validation should go here"""
+        """Any post initialization validation should go here."""
         if self.start > self.end:
             raise ValueError(f"start > end: {self.start} > {self.end}")
         if self.start < 1:
@@ -208,7 +208,7 @@ class AlternateLocus:
 
     @staticmethod
     def parse(value: str) -> "AlternateLocus":
-        """Parse the genomic interval of format: `<contig>:<start>-<end>`"""
+        """Parse the genomic interval of format: `<contig>:<start>-<end>`."""
         name, rest = value.split(":", maxsplit=1)
         start, end = rest.split("-", maxsplit=1)
         return AlternateLocus(name=name, start=int(start), end=int(end))
@@ -253,7 +253,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
     attributes: Dict[Keys | str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Any post initialization validation should go here"""
+        """Any post initialization validation should go here."""
         if self.length < 0:
             raise ValueError(f"Length must be >= 0 for '{self.name}'")
         if re.search(SEQUENCE_NAME_PATTERN, self.name) is None:
@@ -265,7 +265,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     @property
     def aliases(self) -> List[str]:
-        """The aliases (not including the primary) name"""
+        """The aliases (not including the primary) name."""
         aliases = self.attributes.get(Keys.ALIASES)
         return [] if aliases is None else aliases.split(",")
 
@@ -276,7 +276,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     @property
     def alternate(self) -> AlternateLocus | None:
-        """Gets the alternate locus for this sequence"""
+        """Gets the alternate locus for this sequence."""
         if Keys.ALTERNATE_LOCUS not in self.attributes:
             return None
         value = self.attributes[Keys.ALTERNATE_LOCUS]
@@ -289,7 +289,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     @property
     def is_alternate(self) -> bool:
-        """True if there is an alternate locus defined, False otherwise"""
+        """True if there is an alternate locus defined, False otherwise."""
         return self.alternate is not None
 
     @property
@@ -435,7 +435,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
     def same_as(self, other: "SequenceDictionary") -> bool:
         """
         Returns true if the sequences share a common reference name (including aliases), have
-        the same length, and the same MD5 if both have MD5s
+        the same length, and the same MD5 if both have MD5s.
         """
         if len(self) != len(other):
             return False
@@ -522,7 +522,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
     def get_by_name(self, name: str) -> SequenceMetadata | None:
         """
         Gets a `SequenceMetadata` explicitly by `name`.  Returns None if
-        the name does not exist in this dictionary
+        the name does not exist in this dictionary.
         """
         return self._dict.get(name)
 

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -178,8 +178,10 @@ class Keys(StrEnum):
 
     @staticmethod
     def attributes() -> List[str]:
-        """The list of keys that are allowed to be attributes in `SequenceMetadata`.  Notably
-        `SEQUENCE_LENGTH` and `SEQUENCE_NAME` are not allowed."""
+        """
+        The list of keys that are allowed to be attributes in `SequenceMetadata`.  Notably
+        `SEQUENCE_LENGTH` and `SEQUENCE_NAME` are not allowed.
+        """
         return [key for key in Keys if key != Keys.SEQUENCE_NAME and key != Keys.SEQUENCE_LENGTH]
 
 
@@ -220,7 +222,8 @@ SEQUENCE_NAME_PATTERN: Pattern = re.compile(
 
 @dataclass(frozen=True, init=True)
 class SequenceMetadata(MutableMapping[Keys | str, str]):
-    """Stores information about a single Sequence (ex. chromosome, contig).
+    """
+    Stores information about a single Sequence (ex. chromosome, contig).
 
     Implements the mutable mapping interface, which provides access to the attributes of this
     sequence, including name, length, but not index.  When using the mapping interface, for example
@@ -315,8 +318,10 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
         return None if value is None else Topology[value]
 
     def same_as(self, other: "SequenceMetadata") -> bool:
-        """Returns true if the sequences share a common reference name (including aliases), have
-        the same length, and the same MD5 if both have MD5s."""
+        """
+        Returns true if the sequences share a common reference name (including aliases), have
+        the same length, and the same MD5 if both have MD5s.
+        """
         if self.length != other.length:
             return False
         elif self.name != other.name and other.name not in self.all_names:
@@ -329,8 +334,10 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
             return self_m5 == other_m5
 
     def to_sam(self) -> Dict[str, Any]:
-        """Converts the sequence metadata to a dictionary equivalent to one item in the
-        list of sequences from `pysam.AlignmentHeader#to_dict()["SQ"]`."""
+        """
+        Converts the sequence metadata to a dictionary equivalent to one item in the
+        list of sequences from `pysam.AlignmentHeader#to_dict()["SQ"]`.
+        """
         meta_dict: Dict[str, Any] = {
             f"{Keys.SEQUENCE_NAME}": self.name,
             f"{Keys.SEQUENCE_LENGTH}": self.length,
@@ -342,7 +349,8 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
     @staticmethod
     def from_sam(meta: Dict[Keys | str, Any], index: int) -> "SequenceMetadata":
-        """Builds a `SequenceMetadata` from a dictionary.  The keys must include the sequence
+        """
+        Builds a `SequenceMetadata` from a dictionary.  The keys must include the sequence
         name (`Keys.SEQUENCE_NAME`) and length (`Keys.SEQUENCE_LENGTH`).  All other keys from
         `Keys` will be stored in the resulting attributes.
 
@@ -392,7 +400,8 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
 
 @dataclass(frozen=True, init=True)
 class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
-    """Contains an ordered collection of sequences.
+    """
+    Contains an ordered collection of sequences.
 
     A specific `SequenceMetadata` may be retrieved by name (`str`) or index (`int`), either by
     using the generic `get` method or by the correspondingly named `by_name` and `by_index` methods.
@@ -424,8 +433,10 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         object.__setattr__(self, "_dict", self_dict)
 
     def same_as(self, other: "SequenceDictionary") -> bool:
-        """Returns true if the sequences share a common reference name (including aliases), have
-        the same length, and the same MD5 if both have MD5s"""
+        """
+        Returns true if the sequences share a common reference name (including aliases), have
+        the same length, and the same MD5 if both have MD5s
+        """
         if len(self) != len(other):
             return False
         return all(this.same_as(that) for this, that in zip(self.infos, other.infos, strict=True))
@@ -438,7 +449,8 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         self,
         extra_header: Dict[str, Any] | None = None,
     ) -> pysam.AlignmentHeader:
-        """Converts the sequence dictionary to a `pysam.AlignmentHeader`.
+        """
+        Converts the sequence dictionary to a `pysam.AlignmentHeader`.
 
         Args:
             extra_header: a dictionary of extra values to add to the header, None otherwise.  See
@@ -472,7 +484,8 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
     def from_sam(
         data: Path | pysam.AlignmentFile | pysam.AlignmentHeader | List[Dict[str, Any]],
     ) -> "SequenceDictionary":
-        """Creates a `SequenceDictionary` from a SAM file or its header.
+        """
+        Creates a `SequenceDictionary` from a SAM file or its header.
 
         Args:
             data: The input may be any of:
@@ -507,8 +520,10 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         return self._dict[key] if isinstance(key, str) else self.infos[key]
 
     def get_by_name(self, name: str) -> SequenceMetadata | None:
-        """Gets a `SequenceMetadata` explicitly by `name`.  Returns None if
-        the name does not exist in this dictionary"""
+        """
+        Gets a `SequenceMetadata` explicitly by `name`.  Returns None if
+        the name does not exist in this dictionary
+        """
         return self._dict.get(name)
 
     def by_name(self, name: str) -> SequenceMetadata:
@@ -516,8 +531,10 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         return self._dict[name]
 
     def by_index(self, index: int) -> SequenceMetadata:
-        """Gets a `SequenceMetadata` explicitly by `name`.  Raises an `IndexError`
-        if the index is out of bounds."""
+        """
+        Gets a `SequenceMetadata` explicitly by `name`.  Raises an `IndexError`
+        if the index is out of bounds.
+        """
         return self.infos[index]
 
     def __iter__(self) -> Iterator[str]:

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -201,9 +201,11 @@ class AlternateLocus:
             raise ValueError(f"start < 1: {self.start}")
 
     def __str__(self) -> str:
+        """Returns the string representation as name:start-end."""
         return f"{self.name}:{self.start}-{self.end}"
 
     def __len__(self) -> int:
+        """Returns the length of the genomic span."""
         return self.end - self.start + 1
 
     @staticmethod
@@ -368,6 +370,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
         return SequenceMetadata(name=name, length=length, index=index, attributes=attributes)
 
     def __getitem__(self, key: Keys | str) -> Any:
+        """Returns the value for the given key."""
         if key == Keys.SEQUENCE_NAME.value:
             return self.name
         elif key == Keys.SEQUENCE_LENGTH.value:
@@ -375,26 +378,32 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
         return self.attributes[key]
 
     def __setitem__(self, key: Keys | str, value: str) -> None:
+        """Sets the value for the given attribute key."""
         if key == Keys.SEQUENCE_NAME or key == Keys.SEQUENCE_LENGTH:
             raise KeyError(f"Cannot set '{key}' on SequenceMetadata with name '{self.name}'")
         self.attributes[key] = value
 
     def __delitem__(self, key: Keys | str) -> None:
+        """Deletes the given attribute key."""
         if key == Keys.SEQUENCE_NAME or key == Keys.SEQUENCE_LENGTH:
             raise KeyError(f"Cannot delete '{key}' on SequenceMetadata with name '{self.name}'")
         del self.attributes[key]
 
     def __iter__(self) -> Iterator[Keys | str]:
+        """Iterates over all keys, starting with name and length."""
         pre_iter = iter((Keys.SEQUENCE_NAME, Keys.SEQUENCE_LENGTH))
         return itertools.chain(pre_iter, iter(self.attributes))
 
     def __len__(self) -> int:
+        """Returns the sequence length."""
         return self.length
 
     def __str__(self) -> str:
+        """Returns the SAM-formatted @SQ line."""
         return "@SQ\t" + "\t".join(f"{key}:{value}" for key, value in self.to_sam().items())
 
     def __index__(self) -> int:
+        """Returns the index of this sequence in the dictionary."""
         return self.index
 
 
@@ -418,6 +427,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
     _dict: Dict[str, SequenceMetadata] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
+        """Builds the internal name-to-metadata lookup dictionary."""
         # Initialize a mapping from sequence name to the sequence metadata for all names
         self_dict: Dict[str, SequenceMetadata] = {}
         for index, info in enumerate(self.infos):
@@ -517,6 +527,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         return seq_dict
 
     def __getitem__(self, key: str | int) -> SequenceMetadata:
+        """Returns the SequenceMetadata by name or index."""
         return self._dict[key] if isinstance(key, str) else self.infos[key]
 
     def get_by_name(self, name: str) -> SequenceMetadata | None:
@@ -538,10 +549,13 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         return self.infos[index]
 
     def __iter__(self) -> Iterator[str]:
+        """Iterates over the sequence names."""
         return iter(self._dict)
 
     def __len__(self) -> int:
+        """Returns the number of sequences in the dictionary."""
         return len(self.infos)
 
     def __str__(self) -> str:
+        """Returns the SAM-formatted string of all sequences."""
         return "\n".join(f"{info}" for info in self.infos)

--- a/fgpyo/fastx/__init__.py
+++ b/fgpyo/fastx/__init__.py
@@ -1,5 +1,5 @@
 """
-# Zipping FASTX Files
+# Zipping FASTX Files.
 
 Zipping a set of FASTA/FASTQ files into a single stream of data is a common task in bioinformatics
 and can be achieved with the [`FastxZipped()`][fgpyo.fastx.FastxZipped] context manager.

--- a/fgpyo/fastx/__init__.py
+++ b/fgpyo/fastx/__init__.py
@@ -41,7 +41,8 @@ from fgpyo.util.types import all_not_none
 
 
 class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
-    """A context manager that will lazily zip over any number of FASTA/FASTQ files.
+    """
+    A context manager that will lazily zip over any number of FASTA/FASTQ files.
 
     Args:
         paths: Paths to the FASTX files to zip over.

--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -1,5 +1,5 @@
 """
-# Module for reading and writing files
+# Module for reading and writing files.
 
 The functions in this module make it easy to:
 
@@ -82,7 +82,7 @@ COMPRESSED_FILE_EXTENSIONS: Set[str] = {".gz", ".bgz"}
 
 def assert_path_is_readable(path: Path) -> None:
     """
-    Checks that file exists and returns True, else raises AssertionError
+    Checks that file exists and returns True, else raises AssertionError.
 
     Args:
         path: a Path to check
@@ -101,7 +101,7 @@ def assert_path_is_readable(path: Path) -> None:
 
 def assert_directory_exists(path: Path) -> None:
     """
-    Asserts that a path exist and is a directory
+    Asserts that a path exist and is a directory.
 
     Args:
         path: Path to check
@@ -114,9 +114,7 @@ def assert_directory_exists(path: Path) -> None:
 
 
 def assert_path_is_writeable(path: Path, parent_must_exist: bool = True) -> None:
-    """
-    A deprecated alias for `assert_path_is_writable()`.
-    """
+    """A deprecated alias for `assert_path_is_writable()`."""
     warnings.warn(
         "assert_path_is_writeable is deprecated, use assert_path_is_writable instead",
         DeprecationWarning,
@@ -178,7 +176,7 @@ def assert_path_is_writable(path: Path, parent_must_exist: bool = True) -> None:
 
 def to_reader(path: Path, threads: int | None = None) -> TextIOWrapper:
     """
-    Opens a Path for reading and based on extension uses open() or gzip_ng.open()
+    Opens a Path for reading and based on extension uses open() or gzip_ng.open().
 
     Args:
         path: Path to read from
@@ -202,8 +200,8 @@ def to_reader(path: Path, threads: int | None = None) -> TextIOWrapper:
 
 
 def to_writer(path: Path, append: bool = False, threads: int | None = None) -> TextIOWrapper:
-    """
-    Opens a Path for writing (or appending) and based on extension uses open() or gzip_ng.open()
+    r"""
+    Opens a Path for writing (or appending) and based on extension uses open() or gzip_ng.open().
 
     Args:
         path: Path to write (or append) to
@@ -267,7 +265,7 @@ def write_lines(
     path: Path, lines_to_write: Iterable[Any], append: bool = False, threads: int | None = None
 ) -> None:
     """
-    Writes (or appends) a file with one line per item in provided iterable
+    Writes (or appends) a file with one line per item in provided iterable.
 
     Args:
         path: Path to write (or append) to
@@ -289,7 +287,7 @@ def write_lines(
 @contextmanager
 def redirect_to_dev_null(file_num: int) -> Generator[None, None, None]:
     """
-    A context manager that redirects output of file handle to /dev/null
+    A context manager that redirects output of file handle to /dev/null.
 
     Args:
         file_num: number of filehandle to redirect.
@@ -313,7 +311,7 @@ def redirect_to_dev_null(file_num: int) -> Generator[None, None, None]:
 
 @contextmanager
 def suppress_stderr() -> Generator[None, None, None]:
-    """A context manager that redirects output of stderr to /dev/null"""
+    """A context manager that redirects output of stderr to /dev/null."""
     with redirect_to_dev_null(file_num=sys.stderr.fileno()):
         yield
 

--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -237,8 +237,9 @@ def to_writer(path: Path, append: bool = False, threads: int | None = None) -> T
 
 def read_lines(path: Path, strip: bool = False, threads: int | None = None) -> Iterator[str]:
     """
-    Takes a path and reads each line into a generator, removing line terminators
-    along the way. By default, only line terminators (CR/LF) are stripped.  The `strip`
+    Reads each line from a path into a generator, removing line terminators.
+
+    By default, only line terminators (CR/LF) are stripped.  The `strip`
     parameter may be used to strip both leading and trailing whitespace from each line.
 
     Args:

--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -81,7 +81,8 @@ COMPRESSED_FILE_EXTENSIONS: Set[str] = {".gz", ".bgz"}
 
 
 def assert_path_is_readable(path: Path) -> None:
-    """Checks that file exists and returns True, else raises AssertionError
+    """
+    Checks that file exists and returns True, else raises AssertionError
 
     Args:
         path: a Path to check
@@ -99,7 +100,8 @@ def assert_path_is_readable(path: Path) -> None:
 
 
 def assert_directory_exists(path: Path) -> None:
-    """Asserts that a path exist and is a directory
+    """
+    Asserts that a path exist and is a directory
 
     Args:
         path: Path to check
@@ -175,7 +177,8 @@ def assert_path_is_writable(path: Path, parent_must_exist: bool = True) -> None:
 
 
 def to_reader(path: Path, threads: int | None = None) -> TextIOWrapper:
-    """Opens a Path for reading and based on extension uses open() or gzip_ng.open()
+    """
+    Opens a Path for reading and based on extension uses open() or gzip_ng.open()
 
     Args:
         path: Path to read from
@@ -199,7 +202,8 @@ def to_reader(path: Path, threads: int | None = None) -> TextIOWrapper:
 
 
 def to_writer(path: Path, append: bool = False, threads: int | None = None) -> TextIOWrapper:
-    """Opens a Path for writing (or appending) and based on extension uses open() or gzip_ng.open()
+    """
+    Opens a Path for writing (or appending) and based on extension uses open() or gzip_ng.open()
 
     Args:
         path: Path to write (or append) to
@@ -234,7 +238,8 @@ def to_writer(path: Path, append: bool = False, threads: int | None = None) -> T
 
 
 def read_lines(path: Path, strip: bool = False, threads: int | None = None) -> Iterator[str]:
-    """Takes a path and reads each line into a generator, removing line terminators
+    """
+    Takes a path and reads each line into a generator, removing line terminators
     along the way. By default, only line terminators (CR/LF) are stripped.  The `strip`
     parameter may be used to strip both leading and trailing whitespace from each line.
 
@@ -261,7 +266,8 @@ def read_lines(path: Path, strip: bool = False, threads: int | None = None) -> I
 def write_lines(
     path: Path, lines_to_write: Iterable[Any], append: bool = False, threads: int | None = None
 ) -> None:
-    """Writes (or appends) a file with one line per item in provided iterable
+    """
+    Writes (or appends) a file with one line per item in provided iterable
 
     Args:
         path: Path to write (or append) to
@@ -282,7 +288,8 @@ def write_lines(
 
 @contextmanager
 def redirect_to_dev_null(file_num: int) -> Generator[None, None, None]:
-    """A context manager that redirects output of file handle to /dev/null
+    """
+    A context manager that redirects output of file handle to /dev/null
 
     Args:
         file_num: number of filehandle to redirect.

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -1,5 +1,5 @@
 """
-Methods for working with Illumina-specific UMIs in SAM files
+Methods for working with Illumina-specific UMIs in SAM files.
 ------------------------------------
 
 The functions in this module make it easy to:

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -1,6 +1,5 @@
 """
 Methods for working with Illumina-specific UMIs in SAM files.
-------------------------------------
 
 The functions in this module make it easy to:
 

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -91,8 +91,9 @@ def copy_umi_from_read_name(
     rec: AlignedSegment, strict: bool = False, remove_umi: bool = False
 ) -> bool:
     """
-    Copy a UMI from an alignment's read name to its `RX` SAM tag. UMI will not be copied to RX
-    tag if invalid.
+    Copy a UMI from an alignment's read name to its `RX` SAM tag.
+
+    The UMI will not be copied to RX tag if it is invalid.
 
     Args:
         rec: The alignment record to update.
@@ -130,6 +131,7 @@ def copy_umi_from_read_name(
 def _is_valid_umi(umi: str) -> bool:
     """
     Check whether a UMI is valid.
+
     Illumina UMIs may only contain A/C/G/T/N.
     https://support.illumina.com/help/BaseSpace_Sequence_Hub_OLH_009008_2/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm
     Args:

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -35,7 +35,8 @@ def extract_umis_from_read_name(
     umi_delimiter: str = _ILLUMINA_UMI_DELIMITER,
     strict: bool = False,
 ) -> str | None:
-    """Extract UMI(s) from an Illumina-style read name.
+    """
+    Extract UMI(s) from an Illumina-style read name.
 
     The UMI is expected to be the final component of the read name, delimited by the
     `read_name_delimiter`. Multiple UMIs may be present, delimited by the `umi_delimiter`. This
@@ -127,13 +128,14 @@ def copy_umi_from_read_name(
 
 
 def _is_valid_umi(umi: str) -> bool:
-    """Check whether a UMI is valid.
+    """
+    Check whether a UMI is valid.
     Illumina UMIs may only contain A/C/G/T/N.
     https://support.illumina.com/help/BaseSpace_Sequence_Hub_OLH_009008_2/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm
     Args:
         umi: The UMI to check.
+
     Returns:
         `True` if the UMI is valid, `False` otherwise.
     """
-
     return len(umi) > 0 and set(umi).issubset(_VALID_UMI_CHARACTERS)

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -123,9 +123,10 @@ class SubReadWithQuals:
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class ReadSegment:
     """
-    Encapsulates all the information about a segment within a read structure. A segment can
-    either have a definite length, in which case length must be Some(Int), or an indefinite length
-    (can be any length, 0 or more) in which case length must be None.
+    Encapsulates all the information about a segment within a read structure.
+
+    A segment can either have a definite length, in which case length must be Some(Int), or an
+    indefinite length (can be any length, 0 or more) in which case length must be None.
 
     Attributes:
         offset: The offset of the read segment in the read.
@@ -146,8 +147,10 @@ class ReadSegment:
     @property
     def fixed_length(self) -> int:
         """
-        The fixed length if there is one. Throws an exception on segments without fixed
-        lengths!
+        The fixed length of this segment.
+
+        Raises:
+            AttributeError: If the segment does not have a fixed length.
         """
         if not self.has_fixed_length:
             raise AttributeError(f"fixed_length called on a variable length segment: {self}")
@@ -173,8 +176,9 @@ class ReadSegment:
 
     def _calculate_end(self, bases: str) -> int:
         """
-        Checks some requirements and then calculates the end position for the segment for the
-        given read.
+        Calculates the end position for the segment for the given read.
+
+        Checks that the read is long enough to contain this segment.
         """
         bases_len = len(bases)
         assert bases_len >= self.offset, f"Read ends before the segment starts: {self}"
@@ -204,9 +208,11 @@ class ReadSegment:
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class ReadStructure(Iterable[ReadSegment]):
     """
-    Describes the structure of a give read.  A read contains one or more read segments. A read
-    segment describes a contiguous stretch of bases of the same type (ex. template bases) of some
-    length and some offset from the start of the read.
+    Describes the structure of a given read.
+
+    A read contains one or more read segments. A read segment describes a contiguous stretch of
+    bases of the same type (ex. template bases) of some length and some offset from the start
+    of the read.
 
     Attributes:
          segments: The segments composing the read structure
@@ -228,8 +234,10 @@ class ReadStructure(Iterable[ReadSegment]):
     @property
     def fixed_length(self) -> int:
         """
-        The fixed length if there is one. Throws an exception on segments without fixed
-        lengths!
+        The fixed length of this read structure.
+
+        Raises:
+            AttributeError: If the read structure does not have a fixed length.
         """
         if not self.has_fixed_length:
             raise AttributeError(f"fixed_length called on a variable length read structure: {self}")
@@ -241,10 +249,7 @@ class ReadStructure(Iterable[ReadSegment]):
         return len(self.segments)
 
     def with_variable_last_segment(self) -> "ReadStructure":
-        """
-        Generates a new ReadStructure that is the same as this one except that the last segment
-        has undefined length.
-        """
+        """Returns a copy with the last segment changed to undefined length."""
         last_segment = self.segments[-1]
         if not last_segment.has_fixed_length:
             return self
@@ -387,10 +392,7 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @classmethod
     def _invalid(cls, msg: str, rs: str, start: int, end: int) -> None:
-        """
-        Inserts square brackets around the characters in the read structure that are causing the
-        error.
-        """
+        """Inserts square brackets around the error-causing characters in the read structure."""
         prefix = rs[:start]
         error = rs[start:end]
         suffix = "" if end == len(rs) else rs[end:]

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -1,5 +1,5 @@
 """
-## Classes for representing Read Structures
+## Classes for representing Read Structures.
 
 A Read Structure refers to a String that describes how the bases in a sequencing run should be
 allocated into logical reads.  It serves a similar purpose to the --use-bases-mask in Illumina's
@@ -63,7 +63,7 @@ ANY_LENGTH_CHAR: str = "+"
 
 @enum.unique
 class SegmentType(enum.Enum):
-    """The type of segments that can show up in a read structure"""
+    """The type of segments that can show up in a read structure."""
 
     Template = "T"
     """The segment type for template bases."""
@@ -102,7 +102,7 @@ class SubReadWithoutQuals:
 
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class SubReadWithQuals:
-    """Contains the bases and qualities that correspond to the given read segment"""
+    """Contains the bases and qualities that correspond to the given read segment."""
 
     bases: str
     """The sub-read bases that correspond to the given read segment."""
@@ -215,12 +215,12 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @property
     def _min_length(self) -> int:
-        """The minimum length read that this read structure can process"""
+        """The minimum length read that this read structure can process."""
         return sum(segment.fixed_length for segment in self.segments if segment.has_fixed_length)
 
     @property
     def has_fixed_length(self) -> bool:
-        """True if the ReadStructure has a fixed (i.e. non-variable) length"""
+        """True if the ReadStructure has a fixed (i.e. non-variable) length."""
         return self.segments[-1].has_fixed_length
 
     @property
@@ -235,13 +235,13 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @property
     def length(self) -> int:
-        """Length is defined as the number of segments (not bases!) in the read structure"""
+        """Length is defined as the number of segments (not bases!) in the read structure."""
         return len(self.segments)
 
     def with_variable_last_segment(self) -> "ReadStructure":
         """
         Generates a new ReadStructure that is the same as this one except that the last segment
-        has undefined length
+        has undefined length.
         """
         last_segment = self.segments[-1]
         if not last_segment.has_fixed_length:
@@ -293,7 +293,7 @@ class ReadStructure(Iterable[ReadSegment]):
     def from_segments(
         cls, segments: Tuple[ReadSegment, ...], reset_offsets: bool = False
     ) -> "ReadStructure":
-        """Creates a new ReadStructure, optionally resetting the offsets on each of the segments"""
+        """Creates a new ReadStructure, optionally resetting the offsets on each of the segments."""
         # Check that none but the last segment has an indefinite length
         assert all(s.has_fixed_length for s in segments[:-1]), (
             f"Variable length ({ANY_LENGTH_CHAR}) can only be used in the last segment: "

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -81,6 +81,7 @@ class SegmentType(enum.Enum):
     """The segment type for bases that need to be skipped."""
 
     def __str__(self) -> str:
+        """Returns the single-character value of this segment type."""
         return self.value
 
 
@@ -193,6 +194,7 @@ class ReadSegment:
             return attr.evolve(self, length=new_length)
 
     def __str__(self) -> str:
+        """Returns the string representation of this segment (e.g. '10T' or '+T')."""
         if self.has_fixed_length:
             return f"{self.length}{self.kind.value}"
         else:
@@ -278,15 +280,19 @@ class ReadStructure(Iterable[ReadSegment]):
         return self.segments_by_kind(kind=SegmentType.Skip)
 
     def __iter__(self) -> Iterator[ReadSegment]:
+        """Iterates over the read segments."""
         return iter(self.segments)
 
     def __str__(self) -> str:
+        """Returns the string representation of the full read structure."""
         return "".join(str(s) for s in self.segments)
 
     def __len__(self) -> int:
+        """Returns the total length of the read structure."""
         return self.length
 
     def __getitem__(self, index: int) -> ReadSegment:
+        """Returns the segment at the given index."""
         return self.segments[index]
 
     @classmethod

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -265,18 +265,23 @@ class ReadStructure(Iterable[ReadSegment]):
         return tuple([segment for segment in self if segment.kind == kind])
 
     def template_segments(self) -> Tuple[ReadSegment, ...]:
+        """Returns segments of kind Template."""
         return self.segments_by_kind(kind=SegmentType.Template)
 
     def sample_barcode_segments(self) -> Tuple[ReadSegment, ...]:
+        """Returns segments of kind SampleBarcode."""
         return self.segments_by_kind(kind=SegmentType.SampleBarcode)
 
     def molecular_barcode_segments(self) -> Tuple[ReadSegment, ...]:
+        """Returns segments of kind MolecularBarcode."""
         return self.segments_by_kind(kind=SegmentType.MolecularBarcode)
 
     def cell_barcode_segments(self) -> Tuple[ReadSegment, ...]:
+        """Returns segments of kind CellBarcode."""
         return self.segments_by_kind(kind=SegmentType.CellBarcode)
 
     def skip_segments(self) -> Tuple[ReadSegment, ...]:
+        """Returns segments of kind Skip."""
         return self.segments_by_kind(kind=SegmentType.Skip)
 
     def __iter__(self) -> Iterator[ReadSegment]:
@@ -324,6 +329,7 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @classmethod
     def from_string(cls, segments: str) -> "ReadStructure":
+        """Parses a read structure from its string representation."""
         # Check that none but the last segment has an indefinite length
         tidied = "".join(ch for ch in segments.upper() if not ch.isspace())
         return cls.from_segments(segments=cls._from_string(string=tidied), reset_offsets=True)

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -121,7 +121,8 @@ class SubReadWithQuals:
 
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class ReadSegment:
-    """Encapsulates all the information about a segment within a read structure. A segment can
+    """
+    Encapsulates all the information about a segment within a read structure. A segment can
     either have a definite length, in which case length must be Some(Int), or an indefinite length
     (can be any length, 0 or more) in which case length must be None.
 
@@ -143,8 +144,10 @@ class ReadSegment:
 
     @property
     def fixed_length(self) -> int:
-        """The fixed length if there is one. Throws an exception on segments without fixed
-        lengths!"""
+        """
+        The fixed length if there is one. Throws an exception on segments without fixed
+        lengths!
+        """
         if not self.has_fixed_length:
             raise AttributeError(f"fixed_length called on a variable length segment: {self}")
 
@@ -168,8 +171,10 @@ class ReadSegment:
         )
 
     def _calculate_end(self, bases: str) -> int:
-        """Checks some requirements and then calculates the end position for the segment for the
-        given read."""
+        """
+        Checks some requirements and then calculates the end position for the segment for the
+        given read.
+        """
         bases_len = len(bases)
         assert bases_len >= self.offset, f"Read ends before the segment starts: {self}"
         assert self.length is None or bases_len >= self.offset + self.length, (
@@ -196,7 +201,8 @@ class ReadSegment:
 
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class ReadStructure(Iterable[ReadSegment]):
-    """Describes the structure of a give read.  A read contains one or more read segments. A read
+    """
+    Describes the structure of a give read.  A read contains one or more read segments. A read
     segment describes a contiguous stretch of bases of the same type (ex. template bases) of some
     length and some offset from the start of the read.
 
@@ -219,8 +225,10 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @property
     def fixed_length(self) -> int:
-        """The fixed length if there is one. Throws an exception on segments without fixed
-        lengths!"""
+        """
+        The fixed length if there is one. Throws an exception on segments without fixed
+        lengths!
+        """
         if not self.has_fixed_length:
             raise AttributeError(f"fixed_length called on a variable length read structure: {self}")
         return self._min_length
@@ -231,8 +239,10 @@ class ReadStructure(Iterable[ReadSegment]):
         return len(self.segments)
 
     def with_variable_last_segment(self) -> "ReadStructure":
-        """Generates a new ReadStructure that is the same as this one except that the last segment
-        has undefined length"""
+        """
+        Generates a new ReadStructure that is the same as this one except that the last segment
+        has undefined length
+        """
         last_segment = self.segments[-1]
         if not last_segment.has_fixed_length:
             return self
@@ -365,8 +375,10 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @classmethod
     def _invalid(cls, msg: str, rs: str, start: int, end: int) -> None:
-        """Inserts square brackets around the characters in the read structure that are causing the
-        error."""
+        """
+        Inserts square brackets around the characters in the read structure that are causing the
+        error.
+        """
         prefix = rs[:start]
         error = rs[start:end]
         suffix = "" if end == len(rs) else rs[end:]

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -109,7 +109,7 @@ square brackets.
 >>> cigar = Cigar.from_cigarstring("10M5U")
 Traceback (most recent call last):
     ...
-fgpyo.sam.CigarParsingError: Malformed cigar: 10M5[U]
+fgpyo.sam.CigarParsingException: Malformed cigar: 10M5[U]
 
 ```
 
@@ -517,7 +517,7 @@ class CigarElement:
         return f"{self.length}{self.operator.character}"
 
 
-class CigarParsingError(Exception):
+class CigarParsingException(Exception):  # noqa: N818
     """The exception raised specific to parsing a cigar."""
 
     pass
@@ -552,17 +552,17 @@ class Cigar:
                 elements.append(CigarElement(length, operator))
             return Cigar(tuple(elements))
         except Exception as ex:
-            raise CigarParsingError(f"Malformed cigar tuples: {cigartuples}") from ex
+            raise CigarParsingException(f"Malformed cigar tuples: {cigartuples}") from ex
 
     @classmethod
-    def _pretty_cigarstring_exception(cls, cigarstring: str, index: int) -> CigarParsingError:
+    def _pretty_cigarstring_exception(cls, cigarstring: str, index: int) -> CigarParsingException:
         """Raises an exception highlighting the malformed character."""
         prefix = cigarstring[:index]
         character = cigarstring[index] if index < len(cigarstring) else ""
         suffix = cigarstring[index + 1 :]
         pretty_cigarstring = f"{prefix}[{character}]{suffix}"
         message = f"Malformed cigar: {pretty_cigarstring}"
-        return CigarParsingError(message)
+        return CigarParsingException(message)
 
     @classmethod
     def from_cigarstring(cls, cigarstring: str) -> "Cigar":
@@ -576,7 +576,7 @@ class Cigar:
 
         cigarstring_length = len(cigarstring)
         if cigarstring_length == 0:
-            raise CigarParsingError("Cigar string was empty")
+            raise CigarParsingException("Cigar string was empty")
 
         elements = []
         i = 0

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -980,8 +980,9 @@ class SupplementaryAlignment:
     @staticmethod
     def parse(string: str) -> "SupplementaryAlignment":
         """
-        Returns a supplementary alignment parsed from the given string.  The various fields
-        should be comma-delimited (ex. `chr1,123,-,100M50S,60,4`).
+        Returns a supplementary alignment parsed from the given string.
+
+        The various fields should be comma-delimited (ex. `chr1,123,-,100M50S,60,4`).
         """
         fields = string.split(",")
         return SupplementaryAlignment(
@@ -996,10 +997,11 @@ class SupplementaryAlignment:
     @staticmethod
     def parse_sa_tag(tag: str) -> List["SupplementaryAlignment"]:
         """
-        Parses an SA tag of supplementary alignments from a BAM file. If the tag is empty
-        or contains just a single semi-colon then an empty list will be returned.  Otherwise
-        a list containing a SupplementaryAlignment per ;-separated value in the tag will
-        be returned.
+        Parses an SA tag of supplementary alignments from a BAM file.
+
+        If the tag is empty or contains just a single semi-colon then an empty list will be
+        returned.  Otherwise a list containing a SupplementaryAlignment per ;-separated value
+        in the tag will be returned.
         """
         return [SupplementaryAlignment.parse(a) for a in tag.split(";") if len(a) > 0]
 
@@ -1233,9 +1235,9 @@ def calculate_edit_info(  # noqa: C901 (11 > 10)
     reference_offset: int | None = None,
 ) -> ReadEditInfo | None:
     """
-    Constructs a `ReadEditInfo` instance giving summary stats about how the read aligns to the
-    reference.  Computes the number of mismatches, indels, indel bases as well as the
-    SAM NM and MD tags.
+    Constructs a `ReadEditInfo` with summary stats about how the read aligns to the reference.
+
+    Computes the number of mismatches, indels, indel bases as well as the SAM NM and MD tags.
 
     Calculation of NM and MD tags is based off of htsjdk:
     https://github.com/samtools/htsjdk/blob/7034b33636b4cb9fec300a2136588e7c12c7ccd5/src/main/java/htsjdk/samtools/util/SequenceUtil.java#L964:L1029
@@ -1344,8 +1346,7 @@ def calculate_edit_info(  # noqa: C901 (11 > 10)
 @attr.s(frozen=True, auto_attribs=True)
 class Template:
     """
-    A container for alignment records corresponding to a single sequenced template
-    or insert.
+    A container for alignment records corresponding to a single sequenced template or insert.
 
     It is strongly preferred that new Template instances be created with `Template.build()`
     which will ensure that reads are stored in the correct Template property, and run basic
@@ -1376,8 +1377,9 @@ class Template:
     @staticmethod
     def iterator(alns: Iterator[AlignedSegment]) -> Iterator["Template"]:
         """
-        Returns an iterator over templates. Assumes the input iterable is queryname grouped,
-        and gathers consecutive runs of records sharing a common query name into templates.
+        Returns an iterator over templates from queryname-grouped alignments.
+
+        Gathers consecutive runs of records sharing a common query name into templates.
         """
         return TemplateIterator(alns)
 
@@ -1561,10 +1563,7 @@ class Template:
 
 
 class TemplateIterator(Iterator[Template]):
-    """
-    An iterator that converts an iterator over query-grouped reads into an iterator
-    over templates.
-    """
+    """An iterator that converts query-grouped reads into templates."""
 
     def __init__(self, iterator: Iterator[AlignedSegment]) -> None:
         """Initializes the iterator from a query-grouped alignment iterator."""

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -1174,7 +1174,7 @@ def set_pair_info(r1: AlignedSegment, r2: AlignedSegment, proper_pair: bool = Tr
     r2.is_read2 = True
     r2.is_read1 = False
 
-    set_mate_info(rec1=r1, rec2=r2, is_proper_pair=lambda a, b: proper_pair)
+    set_mate_info(rec1=r1, rec2=r2, is_proper_pair=lambda _a, _b: proper_pair)
 
 
 @attr.s(frozen=True, auto_attribs=True)

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -245,7 +245,8 @@ _STDOUT_PATHS: List[str] = ["-", "stdout", "/dev/stdout"]
 
 @enum.unique
 class SamFileType(enum.Enum):
-    """Enumeration of valid SAM/BAM/CRAM file types.
+    """
+    Enumeration of valid SAM/BAM/CRAM file types.
 
     Attributes:
         mode (str): The additional mode character to add when opening this file type.
@@ -267,7 +268,8 @@ class SamFileType(enum.Enum):
 
     @classmethod
     def from_path(cls, path: Path | str) -> "SamFileType":
-        """Infers the file type based on the file extension.
+        """
+        Infers the file type based on the file extension.
 
         Args:
             path: the path to the SAM/BAM/CRAM to read or write.
@@ -286,7 +288,8 @@ def _pysam_open(  # noqa: C901
     unmapped: bool = False,
     **kwargs: Any,
 ) -> SamFile:
-    """Opens a SAM/BAM/CRAM for reading or writing.
+    """
+    Opens a SAM/BAM/CRAM for reading or writing.
 
     This function permits reading from standard input and writing to standard output. The specified
     path may be the UNIX conventional `"-"`, the more explicit `"stdin"` or `"stdout"`, or an
@@ -302,7 +305,6 @@ def _pysam_open(  # noqa: C901
         unmapped: True if the file is unmapped and has no sequence dictionary, False otherwise.
         kwargs: any keyword arguments to be passed to `pysam.AlignmentFile`; may not include "mode".
     """
-
     if isinstance(path, (str, Path)):
         if str(path) in _STDIN_PATHS and open_for_reading:
             path = sys.stdin
@@ -355,7 +357,8 @@ def _pysam_open(  # noqa: C901
 
 
 def reader(path: SamPath, file_type: SamFileType | None = None, unmapped: bool = False) -> SamFile:
-    """Opens a SAM/BAM/CRAM for reading.
+    """
+    Opens a SAM/BAM/CRAM for reading.
 
     To read from standard input, provide any of `"-"`, `"stdin"`, or `"/dev/stdin"` as the input
     `path`.
@@ -374,7 +377,8 @@ def writer(
     header: str | Dict[str, Any] | SamHeader,
     file_type: SamFileType | None = None,
 ) -> SamFile:
-    """Opens a SAM/BAM/CRAM for writing.
+    """
+    Opens a SAM/BAM/CRAM for writing.
 
     To write to standard output, provide any of `"-"`, `"stdout"`, or `"/dev/stdout"` as the output
     `path`. **Note**: When writing to `stdout`, the `file_type` _must_ be given.
@@ -422,7 +426,8 @@ class _CigarOpUtil:
 
 @enum.unique
 class CigarOp(enum.Enum):
-    """Enumeration of operators that can appear in a Cigar string.
+    """
+    Enumeration of operators that can appear in a Cigar string.
 
     Attributes:
         code (int): The `~pysam` cigar operator code.
@@ -459,7 +464,8 @@ class CigarOp(enum.Enum):
 
     @staticmethod
     def from_code(code: int) -> "CigarOp":
-        """Returns the operator from the given operator code.
+        """
+        Returns the operator from the given operator code.
 
         Note: this is mainly used to get the operator from :py:mod:`~pysam`.
         """
@@ -478,7 +484,8 @@ class CigarOp(enum.Enum):
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class CigarElement:
-    """Represents an element in a Cigar
+    """
+    Represents an element in a Cigar
 
     Attributes:
         - length (int): the length of the element
@@ -515,7 +522,8 @@ class CigarParsingException(Exception):
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class Cigar:
-    """Class representing a cigar string.
+    """
+    Class representing a cigar string.
 
     Attributes:
         - elements (Tuple[CigarElement, ...]): zero or more cigar elements
@@ -525,7 +533,8 @@ class Cigar:
 
     @classmethod
     def from_cigartuples(cls, cigartuples: List[Tuple[int, int]] | None) -> "Cigar":
-        """Returns a Cigar from a list of tuples returned by pysam.
+        """
+        Returns a Cigar from a list of tuples returned by pysam.
 
         Each tuple denotes the operation and length.  See
         [`CigarOp()`][fgpyo.sam.CigarOp] for more information on the
@@ -554,7 +563,8 @@ class Cigar:
 
     @classmethod
     def from_cigarstring(cls, cigarstring: str) -> "Cigar":
-        """Constructs a Cigar from a string returned by pysam.
+        """
+        Constructs a Cigar from a string returned by pysam.
 
         If "*" is given, returns an empty Cigar.
         """
@@ -608,7 +618,8 @@ class Cigar:
         return sum([elem.length_on_target for elem in self.elements])
 
     def coalesce(self) -> "Cigar":
-        """Returns a new Cigar with adjacent elements of the same operator merged.
+        """
+        Returns a new Cigar with adjacent elements of the same operator merged.
 
         For example, ``Cigar.from_cigarstring("10M10M")`` would be coalesced to
         ``Cigar.from_cigarstring("20M")``.
@@ -679,7 +690,8 @@ class Cigar:
         return start_offset, end_offset
 
     def _truncate(self, length: int, should_count: Callable[[CigarElement], bool]) -> "Cigar":
-        """Truncates the CIGAR to a specified length based on a predicate.
+        """
+        Truncates the CIGAR to a specified length based on a predicate.
 
         This private helper method iterates through CIGAR elements and builds a new CIGAR
         that contains at most `length` bases from elements matching the predicate. Position
@@ -712,7 +724,8 @@ class Cigar:
         return Cigar(tuple(builder))
 
     def truncate_to_query_length(self, length: int) -> "Cigar":
-        """Truncates the CIGAR to the specified query sequence length.
+        """
+        Truncates the CIGAR to the specified query sequence length.
 
         Produces a new CIGAR that includes at most the specified number of bases
         from the query sequence. Only CIGAR operators that consume query bases
@@ -734,7 +747,8 @@ class Cigar:
         return self._truncate(length, lambda e: e.operator.consumes_query)
 
     def truncate_to_target_length(self, length: int) -> "Cigar":
-        """Truncates the CIGAR to the specified reference/target sequence length.
+        """
+        Truncates the CIGAR to the specified reference/target sequence length.
 
         Produces a new CIGAR that includes at most the specified number of bases
         from the reference/target sequence. Only CIGAR operators that consume
@@ -773,7 +787,8 @@ class PairOrientation(enum.Enum):
     def from_recs(  # noqa: C901  # `from_recs` is too complex (11 > 10)
         cls, rec1: AlignedSegment, rec2: AlignedSegment | None = None
     ) -> Optional["PairOrientation"]:
-        """Returns the pair orientation if both reads are mapped to the same reference sequence.
+        """
+        Returns the pair orientation if both reads are mapped to the same reference sequence.
 
         Args:
             rec1: The first record in the pair.
@@ -782,7 +797,6 @@ class PairOrientation(enum.Enum):
         See:
             [`htsjdk.samtools.SamPairUtil.getPairOrientation()`](https://github.com/samtools/htsjdk/blob/c31bc92c24bc4e9552b2a913e52286edf8f8ab96/src/main/java/htsjdk/samtools/SamPairUtil.java#L71-L102)
         """
-
         if rec2 is None:
             rec2_is_unmapped = rec1.mate_is_unmapped
             rec2_reference_id = rec1.next_reference_id
@@ -827,13 +841,13 @@ class PairOrientation(enum.Enum):
 
 
 def isize(rec1: AlignedSegment, rec2: AlignedSegment | None = None) -> int:
-    """Computes the insert size ("template length" or "TLEN") for a pair of records.
+    """
+    Computes the insert size ("template length" or "TLEN") for a pair of records.
 
     Args:
         rec1: The first record in the pair.
         rec2: The second record in the pair. If None, then mate info on `rec1` will be used.
     """
-
     if rec2 is None:
         rec2_is_unmapped = rec1.mate_is_unmapped
         rec2_reference_id = rec1.next_reference_id
@@ -884,7 +898,8 @@ def is_proper_pair(
     orientations: Collection[PairOrientation] = DefaultProperlyPairedOrientations,
     isize: Callable[[AlignedSegment, Optional[AlignedSegment]], int] = isize,
 ) -> bool:
-    """Determines if a pair of records are properly paired or not.
+    """
+    Determines if a pair of records are properly paired or not.
 
     Criteria for records in a proper pair are:
         - Both records are aligned
@@ -920,7 +935,8 @@ def is_proper_pair(
 
 @attr.s(frozen=True, auto_attribs=True)
 class SupplementaryAlignment:
-    """Stores a supplementary alignment record produced by BWA and stored in the SA SAM tag.
+    """
+    Stores a supplementary alignment record produced by BWA and stored in the SA SAM tag.
 
     Attributes:
         reference_name: the name of the reference (i.e. contig, chromosome) aligned to
@@ -958,7 +974,8 @@ class SupplementaryAlignment:
 
     @staticmethod
     def parse(string: str) -> "SupplementaryAlignment":
-        """Returns a supplementary alignment parsed from the given string.  The various fields
+        """
+        Returns a supplementary alignment parsed from the given string.  The various fields
         should be comma-delimited (ex. `chr1,123,-,100M50S,60,4`)
         """
         fields = string.split(",")
@@ -973,7 +990,8 @@ class SupplementaryAlignment:
 
     @staticmethod
     def parse_sa_tag(tag: str) -> List["SupplementaryAlignment"]:
-        """Parses an SA tag of supplementary alignments from a BAM file. If the tag is empty
+        """
+        Parses an SA tag of supplementary alignments from a BAM file. If the tag is empty
         or contains just a single semi-colon then an empty list will be returned.  Otherwise
         a list containing a SupplementaryAlignment per ;-separated value in the tag will
         be returned.
@@ -1000,7 +1018,8 @@ class SupplementaryAlignment:
 
 
 def sum_of_base_qualities(rec: AlignedSegment, min_quality_score: int = 15) -> int:
-    """Calculate the sum of base qualities score for an alignment record.
+    """
+    Calculate the sum of base qualities score for an alignment record.
 
     This function is useful for calculating the "mate score" as implemented in `samtools fixmate`.
     Consistently with `samtools fixmate`, this function returns 0 if the record has no base
@@ -1025,7 +1044,8 @@ def sum_of_base_qualities(rec: AlignedSegment, min_quality_score: int = 15) -> i
 
 
 def _set_common_mate_fields(dest: AlignedSegment, mate_primary: AlignedSegment) -> None:
-    """Set common mate info on a destination alignment from its mate's primary alignment.
+    """
+    Set common mate info on a destination alignment from its mate's primary alignment.
 
     Args:
         dest: The alignment to set the mate info upon.
@@ -1059,7 +1079,8 @@ def set_mate_info(
     is_proper_pair: Callable[[AlignedSegment, AlignedSegment], bool] = is_proper_pair,
     isize: Callable[[AlignedSegment, AlignedSegment], int] = isize,
 ) -> None:
-    """Resets mate pair information between two primary alignments that share a query name.
+    """
+    Resets mate pair information between two primary alignments that share a query name.
 
     Args:
         rec1: The first record in the pair.
@@ -1085,7 +1106,8 @@ def set_mate_info(
 
 
 def set_mate_info_on_secondary(secondary: AlignedSegment, mate_primary: AlignedSegment) -> None:
-    """Set mate info on a secondary alignment from its mate's primary alignment.
+    """
+    Set mate info on a secondary alignment from its mate's primary alignment.
 
     Args:
         secondary: The secondary alignment to set mate information upon.
@@ -1104,7 +1126,8 @@ def set_mate_info_on_secondary(secondary: AlignedSegment, mate_primary: AlignedS
 
 
 def set_mate_info_on_supplementary(supp: AlignedSegment, mate_primary: AlignedSegment) -> None:
-    """Set mate info on a supplementary alignment from its mate's primary alignment.
+    """
+    Set mate info on a supplementary alignment from its mate's primary alignment.
 
     Args:
         supp: The supplementary alignment to set mate information upon.
@@ -1129,7 +1152,8 @@ def set_mate_info_on_supplementary(supp: AlignedSegment, mate_primary: AlignedSe
 
 @deprecated("Use `set_mate_info()` instead. Deprecated after fgpyo 0.8.0.")
 def set_pair_info(r1: AlignedSegment, r2: AlignedSegment, proper_pair: bool = True) -> None:
-    """Resets mate pair information between reads in a pair.
+    """
+    Resets mate pair information between reads in a pair.
 
     Can be handed reads that already have pairing flags setup or independent R1 and R2 records that
     are currently flagged as SE reads.
@@ -1314,7 +1338,8 @@ def calculate_edit_info(  # noqa: C901 (11 > 10)
 
 @attr.s(frozen=True, auto_attribs=True)
 class Template:
-    """A container for alignment records corresponding to a single sequenced template
+    """
+    A container for alignment records corresponding to a single sequenced template
     or insert.
 
     It is strongly preferred that new Template instances be created with `Template.build()`
@@ -1345,8 +1370,10 @@ class Template:
 
     @staticmethod
     def iterator(alns: Iterator[AlignedSegment]) -> Iterator["Template"]:
-        """Returns an iterator over templates. Assumes the input iterable is queryname grouped,
-        and gathers consecutive runs of records sharing a common query name into templates."""
+        """
+        Returns an iterator over templates. Assumes the input iterable is queryname grouped,
+        and gathers consecutive runs of records sharing a common query name into templates.
+        """
         return TemplateIterator(alns)
 
     @staticmethod
@@ -1467,7 +1494,8 @@ class Template:
         is_proper_pair: Callable[[AlignedSegment, AlignedSegment], bool] = is_proper_pair,
         isize: Callable[[AlignedSegment, AlignedSegment], int] = isize,
     ) -> Self:
-        """Reset all mate information on every alignment in the template.
+        """
+        Reset all mate information on every alignment in the template.
 
         Args:
             is_proper_pair: A function that takes two alignments and determines proper pair status.
@@ -1492,13 +1520,13 @@ class Template:
         writer: SamFile,
         primary_only: bool = False,
     ) -> None:
-        """Write the records associated with the template to file.
+        """
+        Write the records associated with the template to file.
 
         Args:
             writer: An open, writable AlignmentFile.
             primary_only: If True, only write primary alignments.
         """
-
         if primary_only:
             rec_iter = self.primary_recs()
         else:
@@ -1512,7 +1540,8 @@ class Template:
         tag: str,
         value: str | int | float | None,
     ) -> None:
-        """Add a tag to all records associated with the template.
+        """
+        Add a tag to all records associated with the template.
 
         Setting a tag to `None` will remove the tag.
 
@@ -1520,7 +1549,6 @@ class Template:
             tag: The name of the tag.
             value: The value of the tag.
         """
-
         assert len(tag) == 2, f"Tags must be 2 characters: {tag}."
 
         for rec in self.all_recs():

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -513,6 +513,7 @@ class CigarElement:
         return self.length if self.operator.consumes_reference else 0
 
     def __str__(self) -> str:
+        """Returns the string representation (e.g. '10M')."""
         return f"{self.length}{self.operator.character}"
 
 
@@ -602,6 +603,7 @@ class Cigar:
         return Cigar(tuple(elements))
 
     def __str__(self) -> str:
+        """Returns the CIGAR string, or '*' if empty."""
         if self.elements:
             return "".join([str(e) for e in self.elements])
         else:
@@ -957,6 +959,7 @@ class SupplementaryAlignment:
     nm: int
 
     def __str__(self) -> str:
+        """Returns the comma-delimited SA tag representation."""
         return ",".join(
             str(item)
             for item in (
@@ -1568,9 +1571,11 @@ class TemplateIterator(Iterator[Template]):
         self._iter = PeekableIterator(iterator)
 
     def __iter__(self) -> Iterator[Template]:
+        """Returns self as the iterator."""
         return self
 
     def __next__(self) -> Template:
+        """Returns the next Template from the query-grouped iterator."""
         name = self._iter.peek().query_name
         recs = self._iter.takewhile(lambda r: r.query_name == name)
         return Template.build(recs, validate=False)

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -109,7 +109,7 @@ square brackets.
 >>> cigar = Cigar.from_cigarstring("10M5U")
 Traceback (most recent call last):
     ...
-fgpyo.sam.CigarParsingException: Malformed cigar: 10M5[U]
+fgpyo.sam.CigarParsingError: Malformed cigar: 10M5[U]
 
 ```
 
@@ -517,7 +517,7 @@ class CigarElement:
         return f"{self.length}{self.operator.character}"
 
 
-class CigarParsingException(Exception):
+class CigarParsingError(Exception):
     """The exception raised specific to parsing a cigar."""
 
     pass
@@ -552,17 +552,17 @@ class Cigar:
                 elements.append(CigarElement(length, operator))
             return Cigar(tuple(elements))
         except Exception as ex:
-            raise CigarParsingException(f"Malformed cigar tuples: {cigartuples}") from ex
+            raise CigarParsingError(f"Malformed cigar tuples: {cigartuples}") from ex
 
     @classmethod
-    def _pretty_cigarstring_exception(cls, cigarstring: str, index: int) -> CigarParsingException:
+    def _pretty_cigarstring_exception(cls, cigarstring: str, index: int) -> CigarParsingError:
         """Raises an exception highlighting the malformed character."""
         prefix = cigarstring[:index]
         character = cigarstring[index] if index < len(cigarstring) else ""
         suffix = cigarstring[index + 1 :]
         pretty_cigarstring = f"{prefix}[{character}]{suffix}"
         message = f"Malformed cigar: {pretty_cigarstring}"
-        return CigarParsingException(message)
+        return CigarParsingError(message)
 
     @classmethod
     def from_cigarstring(cls, cigarstring: str) -> "Cigar":
@@ -576,7 +576,7 @@ class Cigar:
 
         cigarstring_length = len(cigarstring)
         if cigarstring_length == 0:
-            raise CigarParsingException("Cigar string was empty")
+            raise CigarParsingError("Cigar string was empty")
 
         elements = []
         i = 0

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -1,5 +1,5 @@
 """
-# Utility Classes and Methods for SAM/BAM
+# Utility Classes and Methods for SAM/BAM.
 
 This module contains utility classes for working with SAM/BAM files and the data contained
 within them.  This includes i) utilities for opening SAM/BAM files for reading and writing,
@@ -404,7 +404,7 @@ def writer(
 
 
 class _CigarOpUtil:
-    """Some useful constants to speed up methods on CigarOp"""
+    """Some useful constants to speed up methods on CigarOp."""
 
     """A dictionary from the cigar op code to the cigar op char.
 
@@ -485,7 +485,7 @@ class CigarOp(enum.Enum):
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class CigarElement:
     """
-    Represents an element in a Cigar
+    Represents an element in a Cigar.
 
     Attributes:
         - length (int): the length of the element
@@ -553,7 +553,7 @@ class Cigar:
 
     @classmethod
     def _pretty_cigarstring_exception(cls, cigarstring: str, index: int) -> CigarParsingException:
-        """Raises an exception highlighting the malformed character"""
+        """Raises an exception highlighting the malformed character."""
         prefix = cigarstring[:index]
         character = cigarstring[index] if index < len(cigarstring) else ""
         suffix = cigarstring[index + 1 :]
@@ -976,7 +976,7 @@ class SupplementaryAlignment:
     def parse(string: str) -> "SupplementaryAlignment":
         """
         Returns a supplementary alignment parsed from the given string.  The various fields
-        should be comma-delimited (ex. `chr1,123,-,100M50S,60,4`)
+        should be comma-delimited (ex. `chr1,123,-,100M50S,60,4`).
         """
         fields = string.split(",")
         return SupplementaryAlignment(
@@ -1574,9 +1574,7 @@ class TemplateIterator(Iterator[Template]):
 
 
 class SamOrder(enum.Enum):
-    """
-    Enumerations of possible sort orders for a SAM file.
-    """
+    """Enumerations of possible sort orders for a SAM file."""
 
     Unsorted = "unsorted"  #: the SAM / BAM / CRAM is unsorted
     Coordinate = "coordinate"  #: coordinate sorted

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -254,6 +254,7 @@ class SamFileType(enum.Enum):
     """
 
     def __init__(self, mode: str, ext: str) -> None:
+        """Initializes the file type with the given mode and extension."""
         self.mode = mode
         self.extension = ext
 
@@ -449,6 +450,7 @@ class CigarOp(enum.Enum):
     def __init__(
         self, code: int, character: str, consumes_query: bool, consumes_reference: bool
     ) -> None:
+        """Initializes the CIGAR operator with the given code, character, and consumption flags."""
         self.code = code
         self.character = character
         self.consumes_query = consumes_query
@@ -1562,6 +1564,7 @@ class TemplateIterator(Iterator[Template]):
     """
 
     def __init__(self, iterator: Iterator[AlignedSegment]) -> None:
+        """Initializes the iterator from a query-grouped alignment iterator."""
         self._iter = PeekableIterator(iterator)
 
     def __iter__(self) -> Iterator[Template]:

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -1,5 +1,5 @@
 """
-# Classes for generating SAM and BAM files and records for testing
+# Classes for generating SAM and BAM files and records for testing.
 
 This module contains utility classes for the generation of SAM and BAM files and
 alignment records, for use in testing.

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -163,8 +163,10 @@ class SamBuilder:
         attrs: Dict[str, Any] | None,
     ) -> AlignedSegment:
         """
-        Generates a new AlignedSegment.  Sets the segment up with the correct
-        header and adds the RG attribute if not contained in attrs.
+        Generates a new AlignedSegment.
+
+        Sets the segment up with the correct header and adds the RG attribute if not
+        contained in attrs.
 
         Args:
             name: the name of the read/template
@@ -512,7 +514,8 @@ class SamBuilder:
         tmp_file_type: sam.SamFileType | None = None,
     ) -> Path:
         """
-        Write the accumulated records to a file, sorts & indexes it, and returns the Path.
+        Writes the accumulated records to a file, sorts & indexes it, and returns the Path.
+
         If a path is provided, it will be written to, otherwise a temporary file is created
         and returned.
 

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -26,7 +26,8 @@ from fgpyo.sam import SamOrder
 
 
 class SamBuilder:
-    """Builder for constructing one or more sam records (AlignmentSegments in pysam terms).
+    """
+    Builder for constructing one or more sam records (AlignmentSegments in pysam terms).
 
     Provides the ability to manufacture records from minimal arguments, while generating
     any remaining attributes to ensure a valid record.
@@ -52,7 +53,8 @@ class SamBuilder:
 
     @staticmethod
     def default_sd() -> List[Dict[str, Any]]:
-        """Generates the sequence dictionary that is used by default by SamBuilder.
+        """
+        Generates the sequence dictionary that is used by default by SamBuilder.
 
         Matches the names and lengths of the HG19 reference in use in production.
 
@@ -104,7 +106,8 @@ class SamBuilder:
         seed: int = 42,
         sort_order: SamOrder = SamOrder.Coordinate,
     ) -> None:
-        """Initializes a new SamBuilder for generating alignment records and SAM/BAM files.
+        """
+        Initializes a new SamBuilder for generating alignment records and SAM/BAM files.
 
         Args:
             r1_len: The length of R1s to create unless otherwise specified
@@ -117,7 +120,6 @@ class SamBuilder:
             seed: a seed value for random number/string generation
             sort_order: Order to sort records when writing to file, or output of to_sorted_list()
         """
-
         self.r1_len: int = r1_len if r1_len is not None else self.DEFAULT_R1_LENGTH
         self.r2_len: int = r2_len if r2_len is not None else self.DEFAULT_R2_LENGTH
         self.base_quality: int = base_quality
@@ -159,7 +161,8 @@ class SamBuilder:
         mapq: int | None,
         attrs: Dict[str, Any] | None,
     ) -> AlignedSegment:
-        """Generates a new AlignedSegment.  Sets the segment up with the correct
+        """
+        Generates a new AlignedSegment.  Sets the segment up with the correct
         header and adds the RG attribute if not contained in attrs.
 
         Args:
@@ -200,7 +203,8 @@ class SamBuilder:
         secondary: bool = False,
         supplementary: bool = False,
     ) -> None:
-        """Appropriately sets most flag fields on the given read.
+        """
+        Appropriately sets most flag fields on the given read.
 
         Args:
             rec: the read to set the flags on
@@ -225,7 +229,8 @@ class SamBuilder:
         quals: List[int] | None = None,
         cigar: str | None = None,
     ) -> None:
-        """Fills in bases, quals and cigar on a record.
+        """
+        Fills in bases, quals and cigar on a record.
 
         If any of bases, quals or cigar are defined, they must all have the same length/query
         length.  If none are defined then the length parameter is used.  Undefined values are
@@ -238,7 +243,6 @@ class SamBuilder:
             quals: an optional list of qualities for the read
             cigar: an optional cigar string for the read
         """
-
         # Do some validation to make sure all defined things have the same lengths
         lengths = set()
         if bases is not None:
@@ -298,7 +302,8 @@ class SamBuilder:
         strand2: str = "-",
         attrs: Dict[str, Any] | None = None,
     ) -> Tuple[AlignedSegment, AlignedSegment]:
-        """Generates a new pair of reads, adds them to the internal collection, and returns them.
+        """
+        Generates a new pair of reads, adds them to the internal collection, and returns them.
 
         Most fields are optional.
 
@@ -359,7 +364,6 @@ class SamBuilder:
         Returns:
             Tuple[AlignedSegment, AlignedSegment]: The pair of records created, R1 then R2.
         """
-
         if strand1 not in ["+", "-"]:
             raise ValueError(f"Invalid value for strand1: {strand1}")
         if strand2 not in ["+", "-"]:
@@ -432,7 +436,8 @@ class SamBuilder:
         supplementary: bool = False,
         attrs: Dict[str, Any] | None = None,
     ) -> AlignedSegment:
-        """Generates a new single reads, adds them to the internal collection, and returns it.
+        """
+        Generates a new single reads, adds them to the internal collection, and returns it.
 
         Most fields are optional.
 
@@ -476,7 +481,6 @@ class SamBuilder:
         Returns:
             AlignedSegment: The record created
         """
-
         if strand not in ["+", "-"]:
             raise ValueError(f"Invalid value for strand1: {strand}")
         if read_num not in [None, 1, 2]:
@@ -504,7 +508,8 @@ class SamBuilder:
         pred: Callable[[AlignedSegment], bool] = lambda r: True,
         tmp_file_type: sam.SamFileType | None = None,
     ) -> Path:
-        """Write the accumulated records to a file, sorts & indexes it, and returns the Path.
+        """
+        Write the accumulated records to a file, sorts & indexes it, and returns the Path.
         If a path is provided, it will be written to, otherwise a temporary file is created
         and returned.
 

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -505,7 +505,7 @@ class SamBuilder:
         self,
         path: Path | None = None,
         index: bool = True,
-        pred: Callable[[AlignedSegment], bool] = lambda r: True,
+        pred: Callable[[AlignedSegment], bool] = lambda _r: True,
         tmp_file_type: sam.SamFileType | None = None,
     ) -> Path:
         """

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -113,6 +113,7 @@ class SamBuilder:
             r1_len: The length of R1s to create unless otherwise specified
             r2_len: The length of R2s to create unless otherwise specified
             base_quality: The base quality of bases to create unless otherwise specified
+            mapping_quality: The mapping quality of records to create unless otherwise specified
             sd: a sequence dictionary as a list of dicts; defaults to calling default_sd() if None
             rg: a single read group as a dict; defaults to calling default_sd() if None
             extra_header: a dictionary of extra values to add to the header, None otherwise.  See
@@ -210,6 +211,8 @@ class SamBuilder:
             rec: the read to set the flags on
             read_num: Either None for an unpaired read, or 1 or 2
             strand: Either "+" or "-" to indicate strand of the read
+            secondary: If True, set the secondary alignment flag
+            supplementary: If True, set the supplementary alignment flag
         """
         rec.is_paired = read_num is not None
         rec.is_read1 = read_num == 1

--- a/fgpyo/sam/clipping.py
+++ b/fgpyo/sam/clipping.py
@@ -1,5 +1,5 @@
 """
-# Utility Functions for Soft-Clipping records in SAM/BAM Files
+# Utility Functions for Soft-Clipping records in SAM/BAM Files.
 
 This module contains utility functions for soft-clipping reads.  There are four variants
 that support clipping the beginnings and ends of reads, and specifying the amount to be

--- a/fgpyo/sam/clipping.py
+++ b/fgpyo/sam/clipping.py
@@ -192,7 +192,8 @@ def softclip_start_of_alignment_by_ref(
     clipped_base_quality: int | None = None,
     tags_to_invalidate: Iterable[str] = TAGS_TO_INVALIDATE,
 ) -> ClippingInfo:
-    """Soft-clips the start of an alignment by bases_to_clip bases on the reference.
+    """
+    Soft-clips the start of an alignment by bases_to_clip bases on the reference.
 
     Clipping is applied after any existing hard or soft clipping.  E.g. a read with cigar 5S100M
     that is clipped with bases_to_clip=10 will yield a cigar of 15S90M.
@@ -232,7 +233,8 @@ def softclip_end_of_alignment_by_ref(
     clipped_base_quality: int | None = None,
     tags_to_invalidate: Iterable[str] = TAGS_TO_INVALIDATE,
 ) -> ClippingInfo:
-    """Soft-clips the end of an alignment by bases_to_clip bases on the reference.
+    """
+    Soft-clips the end of an alignment by bases_to_clip bases on the reference.
 
     Clipping is applied beforeany existing hard or soft clipping.  E.g. a read with cigar 100M5S
     that is clipped with bases_to_clip=10 will yield a cigar of 90M15S.
@@ -357,7 +359,8 @@ def _read_pos_at_ref_pos(
 def _clip(
     cigar: Cigar, quals: array, bases_to_clip: int, clipped_base_quality: int | None
 ) -> Tuple[Cigar, ClippingInfo]:
-    """Workhorse private clipping method that clips the start of cigars.
+    """
+    Workhorse private clipping method that clips the start of cigars.
 
     Always works on the start of the cigars/quals; end-clipping is accomplished by
     reversing value before calling this function.  Since the function is private it
@@ -367,7 +370,6 @@ def _clip(
     2. The cigar and quals agree on the query length
     2. clipped_base_quality is either None or a valid integer base quality
     """
-
     if any(cig.operator == CigarOp.P for cig in cigar.elements):
         raise ValueError(f"Cannot handle cigars that contain padding: {cigar}")
 

--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -135,30 +135,30 @@ def levenshtein(string1: str, string2: str) -> int:
         string2: second string for comparison
 
     """
-    N: int = len(string1)
-    M: int = len(string2)
-    if N == 0 or M == 0:
-        return max(N, M)
-    # Initialize N + 1 x M + 1 matrix with final row/column representing the empty string.
+    n: int = len(string1)
+    m: int = len(string2)
+    if n == 0 or m == 0:
+        return max(n, m)
+    # Initialize n + 1 x m + 1 matrix with final row/column representing the empty string.
     # Fill in initial values for empty string sub-problem comparisons.
     #   A D C "
     # A - - - 3
     # B - - - 2
     # C - - - 1
     # " 3 2 1 0
-    matrix: List[List[int]] = [[int()] * (M + 1) for _ in range(N + 1)]
-    for j in range(M + 1):
-        matrix[N][j] = M - j
-    for i in range(N + 1):
-        matrix[i][M] = N - i
+    matrix: List[List[int]] = [[int()] * (m + 1) for _ in range(n + 1)]
+    for j in range(m + 1):
+        matrix[n][j] = m - j
+    for i in range(n + 1):
+        matrix[i][m] = n - i
     # Fill in matrix from bottom up using previous sub-problem solutions.
     #   A D C "      A D C "      A D C "      A D C "      A D C "
     # A - - - 3    A - - - 3    A - - 2 3    A - 2 2 3    A 1 2 2 3
     # B - - - 2 -> B - - 1 2 -> B - 1 1 2 -> B 2 1 1 2 -> B 2 1 1 2
     # C - - 0 1    C - 1 0 1    C 2 1 0 1    C 2 1 0 1    C 2 1 0 1
     # " 3 2 1 0    " 3 2 1 0    " 3 2 1 0    " 3 2 1 0    " 3 2 1 0
-    for i in range(N - 1, -1, -1):
-        for j in range(M - 1, -1, -1):
+    for i in range(n - 1, -1, -1):
+        for j in range(m - 1, -1, -1):
             if string1[i] == string2[j]:
                 matrix[i][j] = matrix[i + 1][j + 1]  # No Operation
             else:

--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -109,6 +109,7 @@ def gc_content(bases: str) -> float:
 def hamming(string1: str, string2: str) -> int:
     """
     Calculates hamming distance between two strings, case sensitive.
+
     Strings must be of equal lengths.
 
     Args:

--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -80,7 +80,8 @@ def complement(base: str) -> str:
 
 
 def reverse_complement(bases: str) -> str:
-    """Reverse complements a base sequence.
+    """
+    Reverse complements a base sequence.
 
     Arguments:
         bases: the bases to be reverse complemented.
@@ -170,7 +171,8 @@ def levenshtein(string1: str, string2: str) -> int:
 
 
 def longest_hp_length(bases: str) -> int:
-    """Calculates the length of the longest homopolymer in the input sequence.
+    """
+    Calculates the length of the longest homopolymer in the input sequence.
 
     Args:
         bases: the bases over which to compute
@@ -182,7 +184,8 @@ def longest_hp_length(bases: str) -> int:
 
 
 def longest_homopolymer_length(bases: str) -> int:
-    """Calculates the length of the longest homopolymer in the input sequence.
+    """
+    Calculates the length of the longest homopolymer in the input sequence.
 
     Args:
         bases: the bases over which to compute
@@ -207,7 +210,8 @@ def longest_homopolymer_length(bases: str) -> int:
 
 
 def longest_dinucleotide_run_length(bases: str) -> int:
-    """Number of bases in the longest dinucleotide run in a primer.
+    """
+    Number of bases in the longest dinucleotide run in a primer.
 
     A dinucleotide run is when two nucleotides are repeated in tandem. For example,
     TTGG (length = 4) or AACCAACCAA (length = 10). If there are no such runs, returns 0.
@@ -222,7 +226,8 @@ def longest_dinucleotide_run_length(bases: str) -> int:
 
 
 def longest_multinucleotide_run_length(bases: str, repeat_unit_length: int) -> int:
-    """Number of bases in the longest multi-nucleotide run.
+    """
+    Number of bases in the longest multi-nucleotide run.
 
     A multi-nucleotide run is when N nucleotides are repeated in tandem. For example,
     TTGG (length = 4, N=2) or TAGTAGTAG (length = 9, N = 3). If there are no such runs,

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -82,7 +82,7 @@ else:
 
 
 def is_attr_class(cls: type) -> TypeGuard[type[AttrsInstance]]:
-    """Return True if the class is an attr class, and False otherwise"""
+    """Return True if the class is an attr class, and False otherwise."""
     return hasattr(cls, "__attrs_attrs__")
 
 
@@ -118,7 +118,7 @@ def split_at_given_level(
     decrease_depth_chars: Iterable[str] = ("}", ")", "]"),
 ) -> List[str]:
     """
-    Splits a nested field by its outer-most level
+    Splits a nested field by its outer-most level.
 
     Note that this method may produce incorrect results fields containing strings containing
     unpaired characters that increase or decrease the depth
@@ -237,7 +237,7 @@ def tuple_parser(
         """
         Parses a dictionary value (can do so recursively)
         Note that this tool will fail on tuples containing strings containing
-        unpaired '{', or '}' characters
+        unpaired '{', or '}' characters.
         """
         assert tuple_string[0] == "(", "Tuple val improperly formatted"
         assert tuple_string[-1] == ")", "Tuple val improperly formatted"
@@ -283,9 +283,7 @@ def dict_parser(
     )
 
     def dict_parse(dict_string: str) -> Dict[Any, Any]:
-        """
-        Parses a dictionary value (can do so recursively)
-        """
+        """Parses a dictionary value (can do so recursively)."""
         assert dict_string[0] == "{", "Dict val improperly formatted"
         assert dict_string[-1] == "}", "Dict val improprly formatted"
         dict_string = dict_string[1:-1]
@@ -392,7 +390,7 @@ def _get_parser(  # noqa: C901
 def get_fields_dict(
     cls: _DataclassesOrAttrClass | Type[_DataclassesOrAttrClass],
 ) -> Mapping[str, FieldType]:
-    """Get the fields dict from either a dataclasses or attr dataclass (or instance)"""
+    """Get the fields dict from either a dataclasses or attr dataclass (or instance)."""
     if is_dataclasses_class(cls):
         return _get_dataclasses_fields_dict(cls)
     # Always pass a type to is_attr_class
@@ -407,7 +405,7 @@ def get_fields_dict(
 def get_fields(
     cls: _DataclassesOrAttrClass | Type[_DataclassesOrAttrClass],
 ) -> Tuple[FieldType, ...]:
-    """Get the fields tuple from either a dataclasses or attr dataclass (or instance)"""
+    """Get the fields tuple from either a dataclasses or attr dataclass (or instance)."""
     if is_dataclasses_class(cls):
         return get_dataclasses_fields(cls)
     # Always pass a type to is_attr_class
@@ -428,7 +426,7 @@ def attr_from(
     parsers: Dict[type, Callable[[str], Any]] | None = None,
 ) -> _AttrFromType:
     """
-    Builds an attr or dataclasses class from key-word arguments
+    Builds an attr or dataclasses class from key-word arguments.
 
     Args:
         cls: the attr or dataclasses class to be built
@@ -487,12 +485,12 @@ def attr_from(
 
 
 def _attribute_is_optional(attribute: FieldType) -> bool:
-    """Returns True if the attribute is optional, False otherwise"""
+    """Returns True if the attribute is optional, False otherwise."""
     return typing.get_origin(attribute.type) is Union and isinstance(
         None, typing.get_args(attribute.type)
     )
 
 
 def _attribute_has_default(attribute: FieldType) -> bool:
-    """Returns True if the attribute has a default value, False otherwise"""
+    """Returns True if the attribute has a default value, False otherwise."""
     return attribute.default not in _MISSING_OR_NONE or _attribute_is_optional(attribute)

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -54,11 +54,11 @@ except ImportError:  # pragma: no cover
     # called because the import failed; but they're here to ensure that the function is defined in
     # sections of code that don't know if the import was successful or not.
 
-    def get_attr_fields(cls: type) -> Tuple[dataclasses.Field, ...]:
+    def get_attr_fields(_cls: type) -> Tuple[dataclasses.Field, ...]:
         """Get tuple of fields for attr class. attrs isn't imported so return empty tuple."""
         return ()
 
-    def get_attr_fields_dict(cls: type) -> Dict[str, dataclasses.Field]:
+    def get_attr_fields_dict(_cls: type) -> Dict[str, dataclasses.Field]:
         """Get dict of name->field for attr class. attrs isn't imported so return empty dict."""
         return {}
 

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -239,7 +239,8 @@ def tuple_parser(
 
     def tuple_parse(tuple_string: str) -> Tuple[Any, ...]:
         """
-        Parses a dictionary value (can do so recursively)
+        Parses a dictionary value (can do so recursively).
+
         Note that this tool will fail on tuples containing strings containing
         unpaired '{', or '}' characters.
         """

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:  # pragma: no cover
 else:
 
     class DataclassInstance(Protocol):
+        """Protocol for dataclass instances when _typeshed is unavailable."""
+
         __dataclasses_fields__: ClassVar[Dict[str, dataclasses.Field[Any]]]
 
 
@@ -78,6 +80,8 @@ if TYPE_CHECKING and _use_attr:  # pragma: no cover
 else:
     # https://github.com/python-attrs/attrs/blob/f7f317ae4c3790f23ae027db626593d50e8a4e88/src/attr/_typing_compat.pyi#L9
     class AttrsInstance(Protocol):  # type: ignore[no-redef]
+        """Protocol for attrs instances when attrs is unavailable."""
+
         __attrs_attrs__: ClassVar[Any]
 
 
@@ -108,7 +112,7 @@ def _get_dataclasses_fields_dict(
 
 
 class ParserNotFoundException(Exception):
-    pass
+    """Raised when no parser can be found for a given type."""
 
 
 def split_at_given_level(

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -111,7 +111,7 @@ def _get_dataclasses_fields_dict(
     return {field.name: field for field in get_dataclasses_fields(class_or_instance)}
 
 
-class ParserNotFoundException(Exception):
+class ParserNotFoundError(Exception):
     """Raised when no parser can be found for a given type."""
 
 
@@ -376,7 +376,7 @@ def _get_parser(  # noqa: C901
                     [_get_parser(cls, type(arg), parsers) for arg in typing.get_args(type_)],
                 )
             else:
-                raise ParserNotFoundException(
+                raise ParserNotFoundError(
                     "no parser found for type {}".format(
                         # typing types have no __name__.
                         getattr(type_, "__name__", repr(type_))
@@ -457,7 +457,7 @@ def attr_from(
                     parser = _get_parser(cls=cls, type_=attribute.type, parsers=parsers)
                     return_value = parser(str_value)
                     set_value = True
-                except ParserNotFoundException:
+                except ParserNotFoundError:
                     pass
 
             # try setting by casting

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -111,7 +111,7 @@ def _get_dataclasses_fields_dict(
     return {field.name: field for field in get_dataclasses_fields(class_or_instance)}
 
 
-class ParserNotFoundError(Exception):
+class ParserNotFoundException(Exception):  # noqa: N818
     """Raised when no parser can be found for a given type."""
 
 
@@ -377,7 +377,7 @@ def _get_parser(  # noqa: C901
                     [_get_parser(cls, type(arg), parsers) for arg in typing.get_args(type_)],
                 )
             else:
-                raise ParserNotFoundError(
+                raise ParserNotFoundException(
                     "no parser found for type {}".format(
                         # typing types have no __name__.
                         getattr(type_, "__name__", repr(type_))
@@ -458,7 +458,7 @@ def attr_from(
                     parser = _get_parser(cls=cls, type_=attribute.type, parsers=parsers)
                     return_value = parser(str_value)
                     set_value = True
-                except ParserNotFoundError:
+                except ParserNotFoundException:
                     pass
 
             # try setting by casting

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -125,7 +125,6 @@ def split_at_given_level(
 
     Not currently smart enough to deal with fields enclosed in quotes ('' or "") - TODO
     """
-
     outer_depth_of_split = 0
     current_outer_splits = []
     out_vals: List[str] = []
@@ -313,7 +312,8 @@ def dict_parser(
 def _get_parser(  # noqa: C901
     cls: Type, type_: TypeAlias, parsers: Dict[type, Callable[[str], Any]] | None = None
 ) -> partial:
-    """Attempts to find a parser for a provided type.
+    """
+    Attempts to find a parser for a provided type.
 
     Args:
         cls: the type of the class object this is being parsed for (used to get default val for
@@ -427,7 +427,8 @@ def attr_from(
     kwargs: Dict[str, str],
     parsers: Dict[type, Callable[[str], Any]] | None = None,
 ) -> _AttrFromType:
-    """Builds an attr or dataclasses class from key-word arguments
+    """
+    Builds an attr or dataclasses class from key-word arguments
 
     Args:
         cls: the attr or dataclasses class to be built

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -264,7 +264,7 @@ def dict_parser(
         cls: the type of the class object this is being parsed for (used to get default val for
             parsers)
         type_: the type of the attribute to be parsed
-            parsers: an optional mapping from type to the function to use for parsing that type
+        parsers: an optional mapping from type to the function to use for parsing that type
             (allows for parsing of more complex types)
     """
     subtypes = typing.get_args(type_)

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -66,13 +66,13 @@ def setup_logging(level: str = "INFO", name: str = "fgpyo") -> None:
 
     with __LOCK:
         if not __FGPYO_LOGGING_SETUP:
-            format = (
+            log_format = (
                 f"%(asctime)s {socket.gethostname()} %(name)s:%(funcName)s:%(lineno)s "
                 + "[%(levelname)s]: %(message)s"
             )
             handler = logging.StreamHandler()
             handler.setLevel(level)
-            handler.setFormatter(logging.Formatter(format))
+            handler.setFormatter(logging.Formatter(log_format))
 
             logger = logging.getLogger(name)
             logger.setLevel(level)

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -122,6 +122,7 @@ class ProgressLogger(AbstractContextManager):
     def __exit__(
         self, ex_type: Any | None, ex_value: Any | None, traceback: Any | None
     ) -> Literal[False]:
+        """Logs the final count on exit if no exception occurred."""
         if ex_value is None:
             self.log_last()
         return False

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -105,6 +105,7 @@ class ProgressLogger(AbstractContextManager):
         verb: str = "Read",
         unit: int = 100000,
     ) -> None:
+        """Initializes the progress logger with the given printer and settings."""
         self.printer: Callable[[str], Any]
         if isinstance(printer, Logger):
             self.printer = lambda s: printer.info(s)

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -53,7 +53,7 @@ __LOCK = RLock()
 
 def setup_logging(level: str = "INFO", name: str = "fgpyo") -> None:
     """
-    Globally configure logging for all modules
+    Globally configure logging for all modules.
 
     Configures logging to run at a specific level and output messages to stderr with
     useful information preceding the actual log message.

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -52,7 +52,8 @@ __LOCK = RLock()
 
 
 def setup_logging(level: str = "INFO", name: str = "fgpyo") -> None:
-    """Globally configure logging for all modules
+    """
+    Globally configure logging for all modules
 
     Configures logging to run at a specific level and output messages to stderr with
     useful information preceding the actual log message.
@@ -83,7 +84,8 @@ def setup_logging(level: str = "INFO", name: str = "fgpyo") -> None:
 
 
 class ProgressLogger(AbstractContextManager):
-    """A little class to track progress.
+    """
+    A little class to track progress.
 
     This will output a log message every `unit` number times recorded.
 
@@ -128,7 +130,9 @@ class ProgressLogger(AbstractContextManager):
         reference_name: str | None = None,
         position: int | None = None,
     ) -> bool:
-        """Record an item at a given genomic coordinate.
+        """
+        Record an item at a given genomic coordinate.
+
         Args:
             reference_name: the reference name of the item
             position: the 1-based start position of the item
@@ -150,7 +154,8 @@ class ProgressLogger(AbstractContextManager):
         self,
         rec: AlignedSegment,
     ) -> bool:
-        """Correctly record pysam.AlignedSegments (zero-based coordinates).
+        """
+        Correctly record pysam.AlignedSegments (zero-based coordinates).
 
         Args:
             rec: pysam.AlignedSegment object
@@ -166,7 +171,8 @@ class ProgressLogger(AbstractContextManager):
         self,
         recs: Iterable[AlignedSegment],
     ) -> bool:
-        """Correctly record multiple pysam.AlignedSegments (zero-based coordinates).
+        """
+        Correctly record multiple pysam.AlignedSegments (zero-based coordinates).
 
         Args:
             recs: pysam.AlignedSegment objects
@@ -184,7 +190,8 @@ class ProgressLogger(AbstractContextManager):
         refname: str | None = None,
         position: int | None = None,
     ) -> None:
-        """Helper method to print the log message.
+        """
+        Helper method to print the log message.
 
         Args:
             refname: the name of the reference of the item

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -536,6 +536,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             self._writer.writeheader()
 
     def __enter__(self) -> "MetricWriter":
+        """Returns self for use as a context manager."""
         return self
 
     def __exit__(
@@ -544,6 +545,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Closes the underlying writer on exit."""
         self.close()
         super().__exit__(exc_type, exc_value, traceback)
 

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -207,9 +207,10 @@ class Metric(ABC, Generic[MetricType]):
     @classmethod
     def _parsers(cls) -> Dict[type, Callable[[str], Any]]:
         """
-        Mapping of type to a specific parser for that type.  The parser must accept a string
-        as a single parameter and return a single value of the given type.  Sub-classes may
-        override this method to support custom types.
+        Mapping of type to a specific parser for that type.
+
+        The parser must accept a string as a single parameter and return a single value of
+        the given type.  Sub-classes may override this method to support custom types.
         """
         return {}
 
@@ -296,9 +297,9 @@ class Metric(ABC, Generic[MetricType]):
     @classmethod
     def parse(cls, fields: List[str]) -> Any:
         """
-        Parses the string-representation of this metric.  One string per attribute should be
-        given.
+        Parses the string-representation of this metric.
 
+        One string per attribute should be given.
         """
         parsers = cls._parsers()
         header = cls.header()
@@ -475,6 +476,8 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         threads: int | None = None,
     ) -> None:
         r"""
+        Initializes the MetricWriter.
+
         Args:
             filename: Path to the file to write.
             metric_class: Metric class.

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -169,7 +169,8 @@ class MetricFileHeader:
 
 
 class Metric(ABC, Generic[MetricType]):
-    """Abstract base class for all metric-like tab-delimited files
+    """
+    Abstract base class for all metric-like tab-delimited files
 
     Metric files are tab-delimited, contain a header, and zero or more rows for metric values.  This
     makes it easy for them to be read in languages like `R`.
@@ -207,9 +208,11 @@ class Metric(ABC, Generic[MetricType]):
 
     @classmethod
     def _parsers(cls) -> Dict[type, Callable[[str], Any]]:
-        """Mapping of type to a specific parser for that type.  The parser must accept a string
+        """
+        Mapping of type to a specific parser for that type.  The parser must accept a string
         as a single parameter and return a single value of the given type.  Sub-classes may
-        override this method to support custom types."""
+        override this method to support custom types.
+        """
         return {}
 
     @classmethod
@@ -220,7 +223,8 @@ class Metric(ABC, Generic[MetricType]):
         strip_whitespace: bool = False,
         threads: int | None = None,
     ) -> Iterator[Any]:
-        """Reads in zero or more metrics from the given path.
+        """
+        Reads in zero or more metrics from the given path.
 
         The metric file must contain a matching header.
 
@@ -293,7 +297,8 @@ class Metric(ABC, Generic[MetricType]):
 
     @classmethod
     def parse(cls, fields: List[str]) -> Any:
-        """Parses the string-representation of this metric.  One string per attribute should be
+        """
+        Parses the string-representation of this metric.  One string per attribute should be
         given.
 
         """
@@ -306,7 +311,8 @@ class Metric(ABC, Generic[MetricType]):
 
     @classmethod
     def write(cls, path: Path, *values: MetricType, threads: int | None = None) -> None:
-        """Writes zero or more metrics to the given path.
+        """
+        Writes zero or more metrics to the given path.
 
         The header will always be written.
 
@@ -326,7 +332,8 @@ class Metric(ABC, Generic[MetricType]):
 
     @classmethod
     def format_value(cls, value: Any) -> str:  # noqa: C901
-        """The default method to format values of a given type.
+        """
+        The default method to format values of a given type.
 
         By default, this method will comma-delimit `list`, `tuple`, and `set` types, and apply
         `str` to all others.
@@ -420,7 +427,6 @@ class Metric(ABC, Generic[MetricType]):
         Raises:
             ValueError: If the file was empty or contained only comments or empty lines.
         """
-
         preamble: List[str] = []
         fieldnames: List[str] = []
 
@@ -438,7 +444,6 @@ class Metric(ABC, Generic[MetricType]):
 
 def _is_metric_class(cls: Any) -> TypeGuard[Metric]:
     """True if the given class is a Metric."""
-
     is_metric_cls: bool = isclass(cls) and issubclass(cls, Metric)
 
     try:
@@ -497,7 +502,6 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             ValueError: If `append=True` and the header of the provided file does not match the
                 specified metric class and the specified include/exclude fields.
         """
-
         filepath: Path = Path(filename)
         if (filepath.is_fifo() or filepath.is_char_device()) and append:
             raise ValueError("Cannot append to stdout, stderr, or other named pipe or stream")
@@ -565,7 +569,6 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
             TypeError: If the provided `metric` is not an instance of the Metric class used to
                 parametrize the writer.
         """
-
         # Serialize the Metric to a dict for writing by the underlying `DictWriter`
         row = {fieldname: val for fieldname, val in metric.formatted_items()}
 
@@ -609,7 +612,6 @@ def _validate_and_generate_final_output_fieldnames(
     Raises:
         ValueError: If both `include_fields` and `exclude_fields` are specified.
     """
-
     if include_fields is not None and exclude_fields is not None:
         raise ValueError(
             "Only one of `include_fields` and `exclude_fields` may be specified, not both."

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -192,7 +192,7 @@ class Metric(ABC, Generic[MetricType]):
             yield getattr(self, field.name)
 
     def items(self) -> Iterator[Tuple[str, Any]]:
-        """An iterator over field names and their corresponding values in the same order as the header."""
+        """An iterator over field names and values in the same order as the header."""
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
             yield (field.name, getattr(self, field.name))
 

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -388,6 +388,7 @@ class Metric(ABC, Generic[MetricType]):
 
     @staticmethod
     def fast_concat(*inputs: Path, output: Path) -> None:
+        """Concatenates multiple metric files into one, validating headers match."""
         if len(inputs) == 0:
             raise ValueError("No inputs provided")
 

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -456,6 +456,8 @@ def _is_metric_class(cls: Any) -> TypeGuard[Metric]:
 
 
 class MetricWriter(Generic[MetricType], AbstractContextManager):
+    """Writes Metric instances to a delimited file."""
+
     _metric_class: Type[Metric]
     _fieldnames: List[str]
     _fout: TextIOWrapper

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -1,5 +1,5 @@
 """
-# Metrics
+# Metrics.
 
 Module for storing, reading, and writing metric-like tab-delimited information.
 
@@ -170,7 +170,7 @@ class MetricFileHeader:
 
 class Metric(ABC, Generic[MetricType]):
     """
-    Abstract base class for all metric-like tab-delimited files
+    Abstract base class for all metric-like tab-delimited files.
 
     Metric files are tab-delimited, contain a header, and zero or more rows for metric values.  This
     makes it easy for them to be read in languages like `R`.
@@ -192,9 +192,7 @@ class Metric(ABC, Generic[MetricType]):
             yield getattr(self, field.name)
 
     def items(self) -> Iterator[Tuple[str, Any]]:
-        """
-        An iterator over field names and their corresponding values in the same order as the header.
-        """
+        """An iterator over field names and their corresponding values in the same order as the header."""
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
             yield (field.name, getattr(self, field.name))
 
@@ -473,7 +471,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         lineterminator: str = "\n",
         threads: int | None = None,
     ) -> None:
-        """
+        r"""
         Args:
             filename: Path to the file to write.
             metric_class: Metric class.
@@ -488,7 +486,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
                 May not be used together with `include_fields`.
             lineterminator: The string used to terminate lines produced by the MetricWriter.
                 Default = "\n".
-            threads: the number of threads to use when compressing gzip files
+            threads: the number of threads to use when compressing gzip files.
 
         Raises:
             TypeError: If the provided metric class is not a dataclass- or attr-decorated

--- a/fgpyo/util/string.py
+++ b/fgpyo/util/string.py
@@ -2,7 +2,8 @@ from typing import List
 
 
 def column_it(rows: List[List[str]], delimiter: str = " ") -> str:
-    """A simple version of Unix's `column` utility.  This assumes the table is NxM.
+    """
+    A simple version of Unix's `column` utility.  This assumes the table is NxM.
 
     Args:
         rows: the rows to adjust.  Each row must have the same number of delimited fields.

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -34,8 +34,9 @@ class InspectError(Exception):
 
 def parse_bool(string: str) -> bool:
     """
-    Parses strings into bools accounting for the many different text representations of bools
-    that can be used.
+    Parses strings into bools.
+
+    Accounts for the many different text representations of bools that can be used.
     """
     if string.lower() in ["t", "true", "1"]:
         return True
@@ -47,8 +48,9 @@ def parse_bool(string: str) -> bool:
 
 def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
     """
-    Worker function behind enum parsing. Takes enum type and creates an instance of the enum
-    from a string if possible.
+    Worker function behind enum parsing.
+
+    Takes an enum type and creates an instance of the enum from a string if possible.
     """
     try:
         return enum(value)
@@ -143,9 +145,10 @@ def _make_union_parser_worker(
     value: str,
 ) -> Optional[UnionType]:
     """
-    Worker function behind union parsing. Iterates through possible parsers for the union and
-    returns the value produced by the first parser that works. Otherwise, raises an error if none
-    work.
+    Worker function behind union parsing.
+
+    Iterates through possible parsers for the union and returns the value produced by the first
+    parser that works. Otherwise, raises an error if none work.
     """
     # Need to do this in the case of type Optional[str], because otherwise it'll return the string
     # 'None' instead of the object None
@@ -168,10 +171,7 @@ def _make_union_parser_worker(
 def make_union_parser(
     union: Type[UnionType], parsers: Iterable[Callable[[str], UnionType]]
 ) -> partial:
-    """
-    Generates a parser function for a union type object and set of parsers for the possible
-    parsers to that union type object.
-    """
+    """Generates a parser function for a union type object."""
     return partial(_make_union_parser_worker, union, parsers)
 
 
@@ -179,9 +179,10 @@ def _make_literal_parser_worker(
     literal: Type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]], value: str
 ) -> LiteralType:
     """
-    Worker function behind literal parsing. Iterates through possible literals and
-    returns the value produced by the first literal that matches expectation.
-    Otherwise raises an error if none work.
+    Worker function behind literal parsing.
+
+    Iterates through possible literals and returns the value produced by the first literal
+    that matches expectation. Otherwise raises an error if none work.
     """
     for arg, p in zip(typing.get_args(literal), parsers, strict=True):
         try:
@@ -201,10 +202,7 @@ def _make_literal_parser_worker(
 def make_literal_parser(
     literal: Type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]]
 ) -> partial:
-    """
-    Generates a parser function for a literal type object and a set of parsers for the possible
-    parsers to that literal type object.
-    """
+    """Generates a parser function for a literal type object."""
     return partial(_make_literal_parser_worker, literal, parsers)
 
 

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -35,7 +35,7 @@ class InspectException(Exception):
 def parse_bool(string: str) -> bool:
     """
     Parses strings into bools accounting for the many different text representations of bools
-    that can be used
+    that can be used.
     """
     if string.lower() in ["t", "true", "1"]:
         return True
@@ -48,7 +48,7 @@ def parse_bool(string: str) -> bool:
 def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
     """
     Worker function behind enum parsing. Takes enum type and creates an instance of the enum
-    from a string if possible
+    from a string if possible.
     """
     try:
         return enum(value)
@@ -61,12 +61,12 @@ def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
 
 
 def make_enum_parser(enum: Type[EnumType]) -> partial:
-    """Makes a parser function for enum classes"""
+    """Makes a parser function for enum classes."""
     return partial(_make_enum_parser_worker, enum)
 
 
 def is_constructible_from_str(type_: type) -> bool:
-    """Returns true if the provided type can be constructed from a string"""
+    """Returns true if the provided type can be constructed from a string."""
     try:
         sig = inspect.signature(type_)
         ((argname, _),) = sig.bind(object()).arguments.items()
@@ -145,7 +145,7 @@ def _make_union_parser_worker(
     """
     Worker function behind union parsing. Iterates through possible parsers for the union and
     returns the value produced by the first parser that works. Otherwise, raises an error if none
-    work
+    work.
     """
     # Need to do this in the case of type Optional[str], because otherwise it'll return the string
     # 'None' instead of the object None
@@ -170,7 +170,7 @@ def make_union_parser(
 ) -> partial:
     """
     Generates a parser function for a union type object and set of parsers for the possible
-    parsers to that union type object
+    parsers to that union type object.
     """
     return partial(_make_union_parser_worker, union, parsers)
 
@@ -181,7 +181,7 @@ def _make_literal_parser_worker(
     """
     Worker function behind literal parsing. Iterates through possible literals and
     returns the value produced by the first literal that matches expectation.
-    Otherwise raises an error if none work
+    Otherwise raises an error if none work.
     """
     for arg, p in zip(typing.get_args(literal), parsers, strict=True):
         try:
@@ -203,18 +203,18 @@ def make_literal_parser(
 ) -> partial:
     """
     Generates a parser function for a literal type object and a set of parsers for the possible
-    parsers to that literal type object
+    parsers to that literal type object.
     """
     return partial(_make_literal_parser_worker, literal, parsers)
 
 
 def is_list_like(type_: type) -> bool:
-    """Returns true if the value is a list or list like object"""
+    """Returns true if the value is a list or list like object."""
     return typing.get_origin(type_) in [list, collections.abc.Iterable, collections.abc.Sequence]
 
 
 def none_parser(value: str) -> Literal[None]:
-    """Returns None if the value is 'None', else raises an error"""
+    """Returns None if the value is 'None', else raises an error."""
     if value == "":
         return None
     raise ValueError(f"NoneType not a valid type for {value}")

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -28,7 +28,7 @@ LiteralType = TypeVar("LiteralType")
 T = TypeVar("T")
 
 
-class InspectException(Exception):
+class InspectError(Exception):
     """Raised when type inspection or parsing fails."""
 
 
@@ -53,7 +53,7 @@ def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
     try:
         return enum(value)
     except KeyError as ex:
-        raise InspectException(
+        raise InspectError(
             "invalid choice: {!r} (choose from {})".format(
                 value, ", ".join(map(repr, enum.__members__))
             )
@@ -154,13 +154,13 @@ def _make_union_parser_worker(
             # mypy doesn't like functions that return None always, so return separately
             none_parser(value)
             return None
-        except (ValueError, InspectException):
+        except (ValueError, InspectError):
             pass
 
     for p in parsers:
         try:
             return p(value)
-        except (ValueError, InspectException):
+        except (ValueError, InspectError):
             pass
     raise ValueError(f"{value} could not be parsed as any of {union}")
 
@@ -191,7 +191,7 @@ def _make_literal_parser_worker(
                 return cast(LiteralType, arg)
         except ValueError:
             pass
-    raise InspectException(
+    raise InspectError(
         "invalid choice: {!r} (choose from {})".format(
             value, ", ".join(map(repr, map(str, typing.get_args(literal))))
         )

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -29,7 +29,7 @@ T = TypeVar("T")
 
 
 class InspectException(Exception):
-    pass
+    """Raised when type inspection or parsing fails."""
 
 
 def parse_bool(string: str) -> bool:

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -33,7 +33,8 @@ class InspectException(Exception):
 
 
 def parse_bool(string: str) -> bool:
-    """Parses strings into bools accounting for the many different text representations of bools
+    """
+    Parses strings into bools accounting for the many different text representations of bools
     that can be used
     """
     if string.lower() in ["t", "true", "1"]:
@@ -45,8 +46,10 @@ def parse_bool(string: str) -> bool:
 
 
 def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
-    """Worker function behind enum parsing. Takes enum type and creates an instance of the enum
-    from a string if possible"""
+    """
+    Worker function behind enum parsing. Takes enum type and creates an instance of the enum
+    from a string if possible
+    """
     try:
         return enum(value)
     except KeyError as ex:
@@ -139,9 +142,11 @@ def _make_union_parser_worker(
     parsers: Iterable[Callable[[str], UnionType]],
     value: str,
 ) -> Optional[UnionType]:
-    """Worker function behind union parsing. Iterates through possible parsers for the union and
+    """
+    Worker function behind union parsing. Iterates through possible parsers for the union and
     returns the value produced by the first parser that works. Otherwise, raises an error if none
-    work"""
+    work
+    """
     # Need to do this in the case of type Optional[str], because otherwise it'll return the string
     # 'None' instead of the object None
     if _is_optional(union):
@@ -163,7 +168,8 @@ def _make_union_parser_worker(
 def make_union_parser(
     union: Type[UnionType], parsers: Iterable[Callable[[str], UnionType]]
 ) -> partial:
-    """Generates a parser function for a union type object and set of parsers for the possible
+    """
+    Generates a parser function for a union type object and set of parsers for the possible
     parsers to that union type object
     """
     return partial(_make_union_parser_worker, union, parsers)
@@ -172,9 +178,11 @@ def make_union_parser(
 def _make_literal_parser_worker(
     literal: Type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]], value: str
 ) -> LiteralType:
-    """Worker function behind literal parsing. Iterates through possible literals and
+    """
+    Worker function behind literal parsing. Iterates through possible literals and
     returns the value produced by the first literal that matches expectation.
-    Otherwise raises an error if none work"""
+    Otherwise raises an error if none work
+    """
     for arg, p in zip(typing.get_args(literal), parsers, strict=True):
         try:
             if p(value) == arg:
@@ -193,7 +201,8 @@ def _make_literal_parser_worker(
 def make_literal_parser(
     literal: Type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]]
 ) -> partial:
-    """Generates a parser function for a literal type object and a set of parsers for the possible
+    """
+    Generates a parser function for a literal type object and a set of parsers for the possible
     parsers to that literal type object
     """
     return partial(_make_literal_parser_worker, literal, parsers)

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -28,7 +28,7 @@ LiteralType = TypeVar("LiteralType")
 T = TypeVar("T")
 
 
-class InspectError(Exception):
+class InspectException(Exception):  # noqa: N818
     """Raised when type inspection or parsing fails."""
 
 
@@ -55,7 +55,7 @@ def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
     try:
         return enum(value)
     except KeyError as ex:
-        raise InspectError(
+        raise InspectException(
             "invalid choice: {!r} (choose from {})".format(
                 value, ", ".join(map(repr, enum.__members__))
             )
@@ -157,13 +157,13 @@ def _make_union_parser_worker(
             # mypy doesn't like functions that return None always, so return separately
             none_parser(value)
             return None
-        except (ValueError, InspectError):
+        except (ValueError, InspectException):
             pass
 
     for p in parsers:
         try:
             return p(value)
-        except (ValueError, InspectError):
+        except (ValueError, InspectException):
             pass
     raise ValueError(f"{value} could not be parsed as any of {union}")
 
@@ -192,7 +192,7 @@ def _make_literal_parser_worker(
                 return cast(LiteralType, arg)
         except ValueError:
             pass
-    raise InspectError(
+    raise InspectException(
         "invalid choice: {!r} (choose from {})".format(
             value, ", ".join(map(repr, map(str, typing.get_args(literal))))
         )

--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -1,5 +1,5 @@
 """
-# Classes for generating VCF and records for testing
+# Classes for generating VCF and records for testing.
 
 This module contains utility classes for the generation of VCF files and variant records, for use
 in testing.
@@ -77,7 +77,7 @@ VcfPath = Path | str | TextIO
 @contextmanager
 def reader(path: VcfPath) -> Generator[VcfReader, None, None]:
     """
-    Opens the given path for VCF reading
+    Opens the given path for VCF reading.
 
     Args:
         path: the path to a VCF, or an open file handle

--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -76,7 +76,8 @@ VcfPath = Path | str | TextIO
 
 @contextmanager
 def reader(path: VcfPath) -> Generator[VcfReader, None, None]:
-    """Opens the given path for VCF reading
+    """
+    Opens the given path for VCF reading
 
     Args:
         path: the path to a VCF, or an open file handle
@@ -95,7 +96,8 @@ def reader(path: VcfPath) -> Generator[VcfReader, None, None]:
 
 @contextmanager
 def writer(path: VcfPath, header: VariantHeader) -> Generator[VcfWriter, None, None]:
-    """Opens the given path for VCF writing.
+    """
+    Opens the given path for VCF writing.
 
     Args:
         path: the path to a VCF, or an open filehandle

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -85,7 +85,8 @@ class VariantBuilder:
         sample_ids: Iterable[str] | None = None,
         sd: Dict[str, Dict[str, Any]] | None = None,
     ) -> None:
-        """Initializes a new VariantBuilder for generating variants and VCF files.
+        """
+        Initializes a new VariantBuilder for generating variants and VCF files.
 
         Args:
             sample_ids: the name of the sample(s)
@@ -103,7 +104,8 @@ class VariantBuilder:
 
     @classmethod
     def default_sd(cls) -> Dict[str, Dict[str, Any]]:
-        """Generates the sequence dictionary that is used by default by VariantBuilder.
+        """
+        Generates the sequence dictionary that is used by default by VariantBuilder.
         Re-uses the dictionary from SamBuilder for consistency.
 
         Returns:
@@ -118,7 +120,8 @@ class VariantBuilder:
 
     @classmethod
     def _build_header_string(cls, sd: Dict[str, Dict[str, Any]] | None = None) -> Iterator[str]:
-        """Builds the VCF header with the given sample name(s) and sequence dictionary.
+        """
+        Builds the VCF header with the given sample name(s) and sequence dictionary.
 
         Args:
             sd: the sequence dictionary mapping the contig name to the key-value pairs for the
@@ -178,7 +181,8 @@ class VariantBuilder:
         info: Dict[str, Any] | None = None,
         samples: Dict[str, Dict[str, Any]] | None = None,
     ) -> VariantRecord:
-        """Generates a new variant and adds it to the internal collection.
+        """
+        Generates a new variant and adds it to the internal collection.
 
         Notes:
         * Very little validation is done with respect to INFO and FORMAT keys being defined in the
@@ -320,7 +324,8 @@ class VariantBuilder:
 
     @staticmethod
     def _to_vcf_path(path: Path | None) -> Path:
-        """Gets the path to a VCF file.  If path is a directory, a temporary VCF will be created in
+        """
+        Gets the path to a VCF file.  If path is a directory, a temporary VCF will be created in
         that directory. If path is `None`, then a temporary VCF will be created.  Otherwise, the
         given path is simply returned.
 
@@ -357,7 +362,8 @@ class VariantBuilder:
         source: str | None = None,
         version: str | None = None,
     ) -> None:
-        """Add an INFO header field to the VCF header.
+        """
+        Add an INFO header field to the VCF header.
 
         Args:
             name: the name of the field

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -42,8 +42,9 @@ MissingRep = Tuple[None, ...] | None
 
 class VariantBuilder:
     """
-    Builder for constructing one or more variant records (pysam.VariantRecord) for a VCF. The VCF
-    can be sites-only, single-sample, or multi-sample.
+    Builder for constructing one or more variant records (pysam.VariantRecord) for a VCF.
+
+    The VCF can be sites-only, single-sample, or multi-sample.
 
     Provides the ability to manufacture variants from minimal arguments, while generating
     any remaining attributes to ensure a valid variant.
@@ -103,7 +104,8 @@ class VariantBuilder:
     @classmethod
     def default_sd(cls) -> Dict[str, Dict[str, Any]]:
         """
-        Generates the sequence dictionary that is used by default by VariantBuilder.
+        Generates the default sequence dictionary for VariantBuilder.
+
         Re-uses the dictionary from SamBuilder for consistency.
 
         Returns:
@@ -272,9 +274,10 @@ class VariantBuilder:
         self, pos: int, ref: str, end: int | None, info: dict[str, Any] | None
     ) -> int:
         """
-        Derives the END/stop position for a new record based on the optionally provided `end`
-        parameter, the presence/absence of END in the info dictionary and/or the length of the
-        reference allele.
+        Derives the END/stop position for a new record.
+
+        Uses the optionally provided `end` parameter, the presence/absence of END in the info
+        dictionary and/or the length of the reference allele.
 
         Also checks that any given or calculated end position is at least greater than or equal
         to the record's position.
@@ -324,9 +327,11 @@ class VariantBuilder:
     @staticmethod
     def _to_vcf_path(path: Path | None) -> Path:
         """
-        Gets the path to a VCF file.  If path is a directory, a temporary VCF will be created in
-        that directory. If path is `None`, then a temporary VCF will be created.  Otherwise, the
-        given path is simply returned.
+        Gets the path to a VCF file.
+
+        If path is a directory, a temporary VCF will be created in that directory. If path is
+        `None`, then a temporary VCF will be created.  Otherwise, the given path is simply
+        returned.
 
         Args:
             path: optionally the path to the VCF, or a directory to create a temporary VCF.

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -15,7 +15,7 @@ from pysam import VariantHeader
 from pysam import VariantRecord
 
 from fgpyo.sam.builder import SamBuilder
-from fgpyo.vcf import writer as PysamWriter
+from fgpyo.vcf import writer as pysam_writer
 
 
 class VcfFieldType(Enum):
@@ -312,7 +312,7 @@ class VariantBuilder:
         path = self._to_vcf_path(path)
 
         # Create a writer and write to it
-        with PysamWriter(path, header=self.header) as writer:
+        with pysam_writer(path, header=self.header) as writer:
             for variant in self.to_sorted_list():
                 writer.write(variant)
 

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -1,6 +1,4 @@
-"""
-# Classes for generating VCF and records for testing
-"""
+"""# Classes for generating VCF and records for testing."""
 
 from enum import Enum
 from pathlib import Path
@@ -21,7 +19,7 @@ from fgpyo.vcf import writer as PysamWriter
 
 
 class VcfFieldType(Enum):
-    """Codes for VCF field types"""
+    """Codes for VCF field types."""
 
     INTEGER = "Integer"
     FLOAT = "Float"
@@ -31,7 +29,7 @@ class VcfFieldType(Enum):
 
 
 class VcfFieldNumber(Enum):
-    """Special codes for VCF field numbers"""
+    """Special codes for VCF field numbers."""
 
     NUM_ALT_ALLELES = "A"
     NUM_ALLELES = "R"
@@ -350,7 +348,7 @@ class VariantBuilder:
         return self.seq_idx_lookup[variant.contig], variant.start, variant.stop
 
     def add_header_line(self, line: str) -> None:
-        """Adds a header line to the header"""
+        """Adds a header line to the header."""
         self.header.add_line(line)
 
     def add_info_header(

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -174,11 +174,11 @@ class VariantBuilder:
         contig: str | None = None,
         pos: int = 1000,
         end: int | None = None,
-        id: str = ".",
+        id: str = ".",  # noqa: A002  # pysam is already shadowing the built-in
         ref: str = "A",
         alts: str | Iterable[str] | None = (".",),
         qual: int = 60,
-        filter: str | Iterable[str] | None = None,
+        filter: str | Iterable[str] | None = None,  # noqa: A002
         info: Dict[str, Any] | None = None,
         samples: Dict[str, Dict[str, Any]] | None = None,
     ) -> VariantRecord:
@@ -232,7 +232,7 @@ class VariantBuilder:
             alts = (alts,)
         alleles = (ref,) if alts is None else (ref, *alts)
         if isinstance(filter, str):
-            filter = (filter,)
+            filter = (filter,)  # noqa: A001  # pysam already shadows the built-in
 
         # pysam expects a list of format dicts provided in the same order as the samples in the
         # header (self.sample_ids). (This is despite the fact that it will internally represent the

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -164,6 +164,7 @@ class VariantBuilder:
 
     @property
     def num_samples(self) -> int:
+        """Returns the number of samples in the VCF."""
         return len(self.sample_ids)
 
     def add(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,14 +82,47 @@ build-backend = "hatchling.build"
 line-length    = 100
 target-version = "py310"
 output-format  = "full"
+preview        = true
 
 [tool.ruff.lint]
-select    = ["C901", "B", "E", "F", "I", "W", "Q"]
-ignore    = ["E203", "E701"]
+select    = [
+    "A",      # Builtin shadowing
+    "ARG",    # Unused arguments
+    "C901",   # McCabe complexity
+    "B",      # bugbear
+    "D",      # pydocstyle (docstrings. We have the "google" convention enabled)
+    "D204",   # Blank line between class docstring and first (__init__) method
+    "D213",   # Summary line should be located on the line after opening quotes
+    "E",      # pycodestyle errors
+    "LOG",    # flake8-logging
+    "LOG015", # (preview rule) Prohibit calls to the root logger
+    "F",      # pyflakes
+    "I",      # isort
+    "N",      # PEP8 naming
+    "W",      # pycodestyle warnings
+    "Q",      # flake8-quotes
+]
+ignore    = [
+    "E203",
+    "E701",
+    "D212",  # summary line should be located on the same line as opening quotes
+    "D100",  # missing docstring in public module
+    "D104",  # missing docstring in public package
+]
 unfixable = ["B"]
+# NB: only preview rules explicitly selected above (e.g. LOG015) will be enforced
+preview = true
+explicit-preview-rules = true
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `D103` Missing docstring in public function in test files
+"tests/**.py" = ["D103"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.mypy]
 files                       = ["./"]

--- a/tests/fgpyo/collections/test_peekable_iterator.py
+++ b/tests/fgpyo/collections/test_peekable_iterator.py
@@ -1,4 +1,4 @@
-"""Tests for :py:mod:`~fgpyo.collections.PeekableIterator`"""
+"""Tests for :py:mod:`~fgpyo.collections.PeekableIterator`."""
 
 import pytest
 

--- a/tests/fgpyo/fasta/test_builder.py
+++ b/tests/fgpyo/fasta/test_builder.py
@@ -10,7 +10,7 @@ from pytest import raises
 from fgpyo.fasta.builder import FastaBuilder
 
 
-def test_overrides_FastaBuilder() -> None:
+def test_overrides_fasta_builder() -> None:
     """Checks that defaults can be overriden in FastaBuilder."""
     builder = FastaBuilder(assembly="HG38", species="Human", line_length=90)
     assert builder.assembly == "HG38"
@@ -18,7 +18,7 @@ def test_overrides_FastaBuilder() -> None:
     assert builder.line_length == 90
 
 
-def test_bases_length_from_ContigBuilder_add_default() -> None:
+def test_bases_length_from_contig_builder_add_default() -> None:
     """Checks that the default addition of bases is a single addition."""
     builder = FastaBuilder()
     builder.add("chr10").add("AAAA")
@@ -32,7 +32,7 @@ def test_bases_length_from_ContigBuilder_add_default() -> None:
         ("chr2", "TTT", 10, 30),
     ],
 )
-def test_bases_length_from_ContigBuilder_add(
+def test_bases_length_from_contig_builder_add(
     name: str,
     bases: str,
     times: int,
@@ -66,7 +66,7 @@ def test_contig_dict_is_not_accessable() -> None:
         ("chr2", "TT T gT", 10, ("TTTGT" * 10)),
     ],
 )
-def test_bases_string_from_ContigBuilder_add(
+def test_bases_string_from_contig_builder_add(
     name: str,
     bases: str,
     times: int,

--- a/tests/fgpyo/fasta/test_builder.py
+++ b/tests/fgpyo/fasta/test_builder.py
@@ -73,7 +73,7 @@ def test_bases_string_from_ContigBuilder_add(
     expected: str,
     tmp_path: Path,
 ) -> None:
-    """Reads bases back from fasta and checks that extra spaces are removed and bases are uppercase."""
+    """Reads bases back from fasta, checks spaces are removed and bases are uppercase."""
     builder = FastaBuilder()
     builder.add(name).add(bases, times)
     with NamedTemp(suffix=".fa", dir=tmp_path, mode="w", delete=True) as fp:

--- a/tests/fgpyo/fasta/test_builder.py
+++ b/tests/fgpyo/fasta/test_builder.py
@@ -1,4 +1,4 @@
-"""Basic tests for reference_set_builder"""
+"""Basic tests for reference_set_builder."""
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile as NamedTemp
@@ -11,7 +11,7 @@ from fgpyo.fasta.builder import FastaBuilder
 
 
 def test_overrides_FastaBuilder() -> None:
-    """Checks that defaults can be overriden in FastaBuilder"""
+    """Checks that defaults can be overriden in FastaBuilder."""
     builder = FastaBuilder(assembly="HG38", species="Human", line_length=90)
     assert builder.assembly == "HG38"
     assert builder.species == "Human"
@@ -38,14 +38,14 @@ def test_bases_length_from_ContigBuilder_add(
     times: int,
     length_bases: int,
 ) -> None:
-    """Checks that the number of bases in each contig is correct"""
+    """Checks that the number of bases in each contig is correct."""
     builder = FastaBuilder()
     builder.add(name).add(bases, times)
     assert len(builder.__getitem__(name).bases) == length_bases
 
 
 def test_override_existing_contig() -> None:
-    """Asserts than an exception is raised when an override is attempted"""
+    """Asserts than an exception is raised when an override is attempted."""
     with raises(AssertionError, match="The contig contig_name already exists,"):
         builder = FastaBuilder()
         builder.add("contig_name")
@@ -53,7 +53,7 @@ def test_override_existing_contig() -> None:
 
 
 def test_contig_dict_is_not_accessable() -> None:
-    """Ensures that an AttributeError is raised if FastaBuilder.__contig_builders is called"""
+    """Ensures that an AttributeError is raised if FastaBuilder.__contig_builders is called."""
     builder = FastaBuilder()
     with raises(AttributeError):
         builder.__contig_builders["test"] = builder.add("chr10")
@@ -73,9 +73,7 @@ def test_bases_string_from_ContigBuilder_add(
     expected: str,
     tmp_path: Path,
 ) -> None:
-    """
-    Reads bases back from fasta and checks that extra spaces are removed and bases are uppercase
-    """
+    """Reads bases back from fasta and checks that extra spaces are removed and bases are uppercase."""
     builder = FastaBuilder()
     builder.add(name).add(bases, times)
     with NamedTemp(suffix=".fa", dir=tmp_path, mode="w", delete=True) as fp:

--- a/tests/fgpyo/fastx/test_fastx_zipped.py
+++ b/tests/fgpyo/fastx/test_fastx_zipped.py
@@ -30,7 +30,7 @@ def test_fastx_zipped_iterates_over_a_single_fasta(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over a single FASTA file."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta = input_dir /"input.fasta"
+    fasta = input_dir / "input.fasta"
     fasta.write_text(">seq1\nACGT\n>seq2\nTGCA\n")
 
     context_manager = FastxZipped(fasta)
@@ -49,7 +49,7 @@ def test_fastx_zipped_iterates_over_a_single_fasta_gzipped(tmp_path: Path) -> No
     """Test that :class:`FastxZipped` can iterate over a single gzipped FASTA file."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta = input_dir /"input.fasta.gz"
+    fasta = input_dir / "input.fasta.gz"
 
     with gzip.open(fasta, "wt") as handle:
         handle.write(">seq1\nACGT\n>seq2\nTGCA\n")
@@ -70,7 +70,7 @@ def test_fastx_zipped_iterates_over_a_single_fastq(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over a single FASTQ file."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fastq = input_dir /"input.fastq"
+    fastq = input_dir / "input.fastq"
     fastq.write_text("@seq1\tcomment1\nACGT\n+\nFFFF\n" + "@seq2\tcomment2\nTGCA\n+\n!!!!\n")
 
     context_manager = FastxZipped(fastq)
@@ -93,8 +93,8 @@ def tests_fastx_zipped_raises_exception_on_truncated_fastx(tmp_path: Path) -> No
     """Test that :class:`FastxZipped` raises an exception on truncated FASTX files."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta1 = input_dir /"input1.fasta"
-    fasta2 = input_dir /"input2.fasta"
+    fasta1 = input_dir / "input1.fasta"
+    fasta2 = input_dir / "input2.fasta"
     fasta1.write_text(">seq1\nAAAA\n")
     fasta2.write_text(">seq1\nCCCC\n>seq2\nGGGG\n")
 
@@ -127,8 +127,8 @@ def tests_fastx_zipped_can_iterate_over_multiple_fastx_files(tmp_path: Path) -> 
     """Test that :class:`FastxZipped` can iterate over multiple FASTX files."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta1 = input_dir /"input1.fasta"
-    fasta2 = input_dir /"input2.fasta"
+    fasta1 = input_dir / "input1.fasta"
+    fasta2 = input_dir / "input2.fasta"
     fasta1.write_text(">seq1\nAAAA\n>seq2\nCCCC\n")
     fasta2.write_text(">seq1\nGGGG\n>seq2\nTTTT\n")
 
@@ -152,9 +152,9 @@ def tests_fastx_zipped_raises_exception_on_mismatched_sequence_names(tmp_path: P
     """Test that :class:`FastxZipped` raises an exception on mismatched sequence names."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta1 = input_dir /"input1.fasta"
-    fasta2 = input_dir /"input2.fasta"
-    fasta3 = input_dir /"input3.fasta"
+    fasta1 = input_dir / "input1.fasta"
+    fasta2 = input_dir / "input2.fasta"
+    fasta3 = input_dir / "input3.fasta"
     fasta1.write_text(">seq1\nAAAA\n")
     fasta2.write_text(">seq2\nCCCC\n")
     fasta3.write_text(">seq1\nGGGG\n")
@@ -174,8 +174,8 @@ def tests_fastx_zipped_handles_sequence_names_with_suffixes(tmp_path: Path) -> N
     """Test that :class:`FastxZipped` does not use sequence name suffixes in equality tests."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta1 = input_dir /"input1.fasta"
-    fasta2 = input_dir /"input2.fasta"
+    fasta1 = input_dir / "input1.fasta"
+    fasta2 = input_dir / "input2.fasta"
     fasta1.write_text(">seq1/1\nAAAA\n")
     fasta2.write_text(">seq1/2\nCCCC\n")
 
@@ -207,8 +207,8 @@ def test_fastx_zipped_accidentally_used_as_iterator_only(tmp_path: Path) -> None
     """Test that :class:`FastxZipped` can also be used as an interator outside a context manager."""
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    fasta1 = input_dir /"input1.fasta"
-    fasta2 = input_dir /"input2.fasta"
+    fasta1 = input_dir / "input1.fasta"
+    fasta2 = input_dir / "input2.fasta"
     fasta1.write_text(">seq1\nAAAA\n>seq2\nCCCC\n")
     fasta2.write_text(">seq1\nGGGG\n>seq2\nTTTT\n")
 

--- a/tests/fgpyo/fastx/test_fastx_zipped.py
+++ b/tests/fgpyo/fastx/test_fastx_zipped.py
@@ -17,9 +17,9 @@ def test_fastx_zipped_requires_at_least_one_fastx() -> None:
 
 def test_fastx_zipped_iterates_one_empty_fastx(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over one empty FASTX file."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fastx = input / "input.fastx"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fastx = input_dir / "input.fastx"
     fastx.write_text("")
 
     with FastxZipped(fastx) as handle:
@@ -28,9 +28,9 @@ def test_fastx_zipped_iterates_one_empty_fastx(tmp_path: Path) -> None:
 
 def test_fastx_zipped_iterates_over_a_single_fasta(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over a single FASTA file."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta = input / "input.fasta"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta = input_dir /"input.fasta"
     fasta.write_text(">seq1\nACGT\n>seq2\nTGCA\n")
 
     context_manager = FastxZipped(fasta)
@@ -47,9 +47,9 @@ def test_fastx_zipped_iterates_over_a_single_fasta(tmp_path: Path) -> None:
 
 def test_fastx_zipped_iterates_over_a_single_fasta_gzipped(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over a single gzipped FASTA file."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta = input / "input.fasta.gz"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta = input_dir /"input.fasta.gz"
 
     with gzip.open(fasta, "wt") as handle:
         handle.write(">seq1\nACGT\n>seq2\nTGCA\n")
@@ -68,9 +68,9 @@ def test_fastx_zipped_iterates_over_a_single_fasta_gzipped(tmp_path: Path) -> No
 
 def test_fastx_zipped_iterates_over_a_single_fastq(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over a single FASTQ file."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fastq = input / "input.fastq"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fastq = input_dir /"input.fastq"
     fastq.write_text("@seq1\tcomment1\nACGT\n+\nFFFF\n" + "@seq2\tcomment2\nTGCA\n+\n!!!!\n")
 
     context_manager = FastxZipped(fastq)
@@ -91,10 +91,10 @@ def test_fastx_zipped_iterates_over_a_single_fastq(tmp_path: Path) -> None:
 
 def tests_fastx_zipped_raises_exception_on_truncated_fastx(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` raises an exception on truncated FASTX files."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta1 = input / "input1.fasta"
-    fasta2 = input / "input2.fasta"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta1 = input_dir /"input1.fasta"
+    fasta2 = input_dir /"input2.fasta"
     fasta1.write_text(">seq1\nAAAA\n")
     fasta2.write_text(">seq1\nCCCC\n>seq2\nGGGG\n")
 
@@ -125,10 +125,10 @@ def tests_fastx_zipped_raises_exception_on_truncated_fastx(tmp_path: Path) -> No
 
 def tests_fastx_zipped_can_iterate_over_multiple_fastx_files(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can iterate over multiple FASTX files."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta1 = input / "input1.fasta"
-    fasta2 = input / "input2.fasta"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta1 = input_dir /"input1.fasta"
+    fasta2 = input_dir /"input2.fasta"
     fasta1.write_text(">seq1\nAAAA\n>seq2\nCCCC\n")
     fasta2.write_text(">seq1\nGGGG\n>seq2\nTTTT\n")
 
@@ -150,11 +150,11 @@ def tests_fastx_zipped_can_iterate_over_multiple_fastx_files(tmp_path: Path) -> 
 
 def tests_fastx_zipped_raises_exception_on_mismatched_sequence_names(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` raises an exception on mismatched sequence names."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta1 = input / "input1.fasta"
-    fasta2 = input / "input2.fasta"
-    fasta3 = input / "input3.fasta"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta1 = input_dir /"input1.fasta"
+    fasta2 = input_dir /"input2.fasta"
+    fasta3 = input_dir /"input3.fasta"
     fasta1.write_text(">seq1\nAAAA\n")
     fasta2.write_text(">seq2\nCCCC\n")
     fasta3.write_text(">seq1\nGGGG\n")
@@ -172,10 +172,10 @@ def tests_fastx_zipped_raises_exception_on_mismatched_sequence_names(tmp_path: P
 
 def tests_fastx_zipped_handles_sequence_names_with_suffixes(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` does not use sequence name suffixes in equality tests."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta1 = input / "input1.fasta"
-    fasta2 = input / "input2.fasta"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta1 = input_dir /"input1.fasta"
+    fasta2 = input_dir /"input2.fasta"
     fasta1.write_text(">seq1/1\nAAAA\n")
     fasta2.write_text(">seq1/2\nCCCC\n")
 
@@ -205,10 +205,10 @@ def tests_fastx_zipped__name_minus_ordinal_works_with_r1_and_r2_ordinals() -> No
 
 def test_fastx_zipped_accidentally_used_as_iterator_only(tmp_path: Path) -> None:
     """Test that :class:`FastxZipped` can also be used as an interator outside a context manager."""
-    input = tmp_path / "input"
-    input.mkdir()
-    fasta1 = input / "input1.fasta"
-    fasta2 = input / "input2.fasta"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    fasta1 = input_dir /"input1.fasta"
+    fasta2 = input_dir /"input2.fasta"
     fasta1.write_text(">seq1\nAAAA\n>seq2\nCCCC\n")
     fasta2.write_text(">seq1\nGGGG\n>seq2\nTTTT\n")
 

--- a/tests/fgpyo/io/test_io.py
+++ b/tests/fgpyo/io/test_io.py
@@ -86,10 +86,7 @@ def test_assert_path_is_writable_pass() -> None:
 
 
 def test_assert_path_is_writeable_raises_deprecation_warning(tmp_path: Path) -> None:
-    """
-    Test that we get a DeprecationWarning when the `assert_path_is_writeable` alias is called,
-    but otherwise works as expected.
-    """
+    """Test that `assert_path_is_writeable` raises a DeprecationWarning but works as expected."""
     with pytest.warns(DeprecationWarning):
         assert_path_is_writeable(path=tmp_path / "test.txt")
 

--- a/tests/fgpyo/io/test_io.py
+++ b/tests/fgpyo/io/test_io.py
@@ -1,4 +1,4 @@
-"""Basic tests for io module"""
+"""Basic tests for io module."""
 
 import io
 import os
@@ -17,7 +17,7 @@ from fgpyo.io import assert_path_is_writeable
 
 
 def test_assert_path_is_readable_missing_file_error() -> None:
-    """Error when file does not exist"""
+    """Error when file does not exist."""
     path = Path("error.txt")
 
     with pytest.raises(AssertionError):
@@ -25,7 +25,7 @@ def test_assert_path_is_readable_missing_file_error() -> None:
 
 
 def test_assert_path_is_readable_mode_error() -> None:
-    """Error when permissions are write only by owner"""
+    """Error when permissions are write only by owner."""
     with NamedTemporaryFile(suffix=".txt", mode="r", delete=True) as write_file:
         path = Path(write_file.name)
         os.chmod(path, stat.S_IWUSR)  # Write only permissions
@@ -35,28 +35,28 @@ def test_assert_path_is_readable_mode_error() -> None:
 
 
 def test_assert_path_is_readable_pass() -> None:
-    """Returns none when no assertions are violated"""
+    """Returns none when no assertions are violated."""
     with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as write_file:
         path = Path(write_file.name)
         fio.assert_path_is_readable(path=path)
 
 
 def test_assert_directory_exists_error() -> None:
-    """Ensure OSError when directory does not exist"""
+    """Ensure OSError when directory does not exist."""
     path = Path("/non/existent/dir/")
     with pytest.raises(AssertionError):
         fio.assert_directory_exists(path)
 
 
 def test_assert_directory_exists_pass() -> None:
-    """Asserts fio._assert_directory_exists() returns True when directory exists"""
+    """Asserts fio._assert_directory_exists() returns True when directory exists."""
     with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as write_file:
         path = Path(write_file.name)
         fio.assert_directory_exists(path=path.parent.absolute())
 
 
 def test_assert_path_is_writable_mode_error() -> None:
-    """Error when permissions are read only by owner"""
+    """Error when permissions are read only by owner."""
     with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as read_file:
         path = Path(read_file.name)
         os.chmod(path, stat.S_IRUSR)  # Read only permissions
@@ -65,21 +65,21 @@ def test_assert_path_is_writable_mode_error() -> None:
 
 
 def test_assert_path_is_writable_parent_not_writable() -> None:
-    """Error when parent_must_exist is false and no writable parent directory exists"""
+    """Error when parent_must_exist is false and no writable parent directory exists."""
     path = Path("/no/parent/exists/")
     with pytest.raises(AssertionError, match="Parent directory is not writable: /"):
         assert_path_is_writable(path=path, parent_must_exist=False)
 
 
 def test_assert_path_is_writable_file_does_not_exist() -> None:
-    """Error when file does not exist"""
+    """Error when file does not exist."""
     path = Path("example/non_existent_file.txt")
     with pytest.raises(AssertionError, match="Parent directory does not exist:"):
         assert_path_is_writable(path=path)
 
 
 def test_assert_path_is_writable_pass() -> None:
-    """Should return the correct writable path"""
+    """Should return the correct writable path."""
     with NamedTemporaryFile(suffix=".txt", mode="w", delete=True) as read_file:
         path = Path(read_file.name)
         assert_path_is_writable(path=path)
@@ -103,7 +103,7 @@ def test_assert_path_is_writeable_raises_deprecation_warning(tmp_path: Path) -> 
     ],
 )
 def test_reader(suffix: str, expected: Any, threads: int | None) -> None:
-    """Tests fgpyo.io.to_reader"""
+    """Tests fgpyo.io.to_reader."""
     with NamedTemporaryFile(suffix=suffix, mode="r", delete=True) as read_file:
         with fio.to_reader(path=Path(read_file.name), threads=threads) as reader:
             assert isinstance(reader, expected)
@@ -118,7 +118,7 @@ def test_reader(suffix: str, expected: Any, threads: int | None) -> None:
     ],
 )
 def test_writer(suffix: str, expected: Any, threads: int | None) -> None:
-    """Tests fgpyo.io.to_writer()"""
+    """Tests fgpyo.io.to_writer()."""
     with NamedTemporaryFile(suffix=suffix, mode="w", delete=True) as write_file:
         with fio.to_writer(path=Path(write_file.name), threads=threads) as writer:
             assert isinstance(writer, expected)
@@ -138,7 +138,7 @@ def test_read_and_write_lines(
     list_to_write: List[Any],
     threads: int | None,
 ) -> None:
-    """Test fgpyo.fio.read_lines and write_lines"""
+    """Test fgpyo.fio.read_lines and write_lines."""
     with NamedTemporaryFile(suffix=suffix, mode="w", delete=True) as read_file:
         fio.write_lines(path=Path(read_file.name), lines_to_write=list_to_write, threads=threads)
         read_back = fio.read_lines(path=Path(read_file.name), threads=threads)

--- a/tests/fgpyo/platform/test_illumina.py
+++ b/tests/fgpyo/platform/test_illumina.py
@@ -20,7 +20,6 @@ from fgpyo.sam.builder import SamBuilder
 )
 def test_is_valid_umi(umi: str, validity: bool) -> None:
     """Test that we can detect valid UMIs."""
-
     assert _is_valid_umi(umi) is validity
 
 
@@ -52,8 +51,10 @@ def test_extract_umi_from_read_name(read_name: str, expected_umi: str) -> None:
     ],
 )
 def test_extract_umi_malformed_raises(read_name: str) -> None:
-    """Test that we raise an error when the number of colon-delimited fields is < 7
-    when strict is True."""
+    """
+    Test that we raise an error when the number of colon-delimited fields is < 7
+    when strict is True.
+    """
     with pytest.raises(ValueError, match="Trying to extract UMIs from read with"):
         extract_umis_from_read_name(read_name=read_name, strict=True)
 
@@ -69,8 +70,10 @@ def test_extract_umi_malformed_raises(read_name: str) -> None:
     ],
 )
 def test_extract_invalid_umi_raises(read_name: str) -> None:
-    """Test that we raise an error when the read name includes an invalid UMI
-    and strict is True."""
+    """
+    Test that we raise an error when the read name includes an invalid UMI
+    and strict is True.
+    """
     with pytest.raises(ValueError, match="Invalid UMIs found in read name"):
         extract_umis_from_read_name(read_name=read_name, strict=True)
 
@@ -88,8 +91,10 @@ def test_extract_invalid_umi_raises(read_name: str) -> None:
     ],
 )
 def test_extract_umi_from_read_name_strict_false(read_name: str, expected_umi: str | None) -> None:
-    """Test that we return None when an invalid UMI is encountered
-    and strict is False. Otherwise, return a valid UMI."""
+    """
+    Test that we return None when an invalid UMI is encountered
+    and strict is False. Otherwise, return a valid UMI.
+    """
     assert extract_umis_from_read_name(read_name=read_name, strict=False) == expected_umi
 
 
@@ -115,8 +120,10 @@ def test_strict_extract_umi_from_read_name(read_name: str, extraction: str) -> N
 
 @pytest.mark.parametrize("remove_umi, strict", [[True, False], [True, False]])
 def test_copy_valid_umi_from_read_name(remove_umi: bool, strict: bool) -> None:
-    """Test that we populate the RX field with a valid UMI if remove_umi and strict
-    are both True; otherwise do not remove UMI from read.query_name."""
+    """
+    Test that we populate the RX field with a valid UMI if remove_umi and strict
+    are both True; otherwise do not remove UMI from read.query_name.
+    """
     builder = SamBuilder()
     read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:GATTACA")
     assert copy_umi_from_read_name(read, strict=strict, remove_umi=remove_umi) is True
@@ -141,8 +148,10 @@ def test_populated_rx_tag_raises() -> None:
 
 
 def test_copy_invalid_umi_from_read_name_raises() -> None:
-    """Test that with an invalid UMI, we raise an error and do not set the RX tag
-    when strict is True."""
+    """
+    Test that with an invalid UMI, we raise an error and do not set the RX tag
+    when strict is True.
+    """
     builder = SamBuilder()
     read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:uvw+xyz")
     assert read.query_name is not None  # type narrowing

--- a/tests/fgpyo/platform/test_illumina.py
+++ b/tests/fgpyo/platform/test_illumina.py
@@ -51,10 +51,7 @@ def test_extract_umi_from_read_name(read_name: str, expected_umi: str) -> None:
     ],
 )
 def test_extract_umi_malformed_raises(read_name: str) -> None:
-    """
-    Test that we raise an error when the number of colon-delimited fields is < 7
-    when strict is True.
-    """
+    """Test that we raise an error when the number of colon-delimited fields is < 7 and strict."""
     with pytest.raises(ValueError, match="Trying to extract UMIs from read with"):
         extract_umis_from_read_name(read_name=read_name, strict=True)
 
@@ -70,10 +67,7 @@ def test_extract_umi_malformed_raises(read_name: str) -> None:
     ],
 )
 def test_extract_invalid_umi_raises(read_name: str) -> None:
-    """
-    Test that we raise an error when the read name includes an invalid UMI
-    and strict is True.
-    """
+    """Test that we raise an error when the read name includes an invalid UMI and strict is True."""
     with pytest.raises(ValueError, match="Invalid UMIs found in read name"):
         extract_umis_from_read_name(read_name=read_name, strict=True)
 
@@ -91,10 +85,7 @@ def test_extract_invalid_umi_raises(read_name: str) -> None:
     ],
 )
 def test_extract_umi_from_read_name_strict_false(read_name: str, expected_umi: str | None) -> None:
-    """
-    Test that we return None when an invalid UMI is encountered
-    and strict is False. Otherwise, return a valid UMI.
-    """
+    """Test that we return None for an invalid UMI when strict is False."""
     assert extract_umis_from_read_name(read_name=read_name, strict=False) == expected_umi
 
 
@@ -120,10 +111,7 @@ def test_strict_extract_umi_from_read_name(read_name: str, extraction: str) -> N
 
 @pytest.mark.parametrize("remove_umi, strict", [[True, False], [True, False]])
 def test_copy_valid_umi_from_read_name(remove_umi: bool, strict: bool) -> None:
-    """
-    Test that we populate the RX field with a valid UMI if remove_umi and strict
-    are both True; otherwise do not remove UMI from read.query_name.
-    """
+    """Test that we populate the RX field with a valid UMI based on remove_umi and strict."""
     builder = SamBuilder()
     read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:GATTACA")
     assert copy_umi_from_read_name(read, strict=strict, remove_umi=remove_umi) is True
@@ -148,10 +136,7 @@ def test_populated_rx_tag_raises() -> None:
 
 
 def test_copy_invalid_umi_from_read_name_raises() -> None:
-    """
-    Test that with an invalid UMI, we raise an error and do not set the RX tag
-    when strict is True.
-    """
+    """Test that with an invalid UMI, we raise an error and do not set the RX tag when strict."""
     builder = SamBuilder()
     read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:uvw+xyz")
     assert read.query_name is not None  # type narrowing

--- a/tests/fgpyo/platform/test_illumina.py
+++ b/tests/fgpyo/platform/test_illumina.py
@@ -1,4 +1,4 @@
-"""Basic tests for Illumina-specific UMI Methods"""
+"""Basic tests for Illumina-specific UMI Methods."""
 
 import pytest
 

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -75,7 +75,6 @@ def test_query_alignment_offsets_reversed(
     """
     cig.revered().query_alignment_offsets() should return the expected results.
     """
-
     cig = Cigar.from_cigarstring(cigar_string)
 
     ret = cig.reversed().query_alignment_offsets()

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -24,9 +24,7 @@ cigar = Cigar.from_cigarstring("1M4D45N37X23I11=")
     ],
 )
 def test_query_alignment_offsets(cigar_string: str, expected_range: Tuple[int, int]) -> None:
-    """
-    cig.query_alignment_offsets() should return the expected results.
-    """
+    """cig.query_alignment_offsets() should return the expected results."""
     cig = Cigar.from_cigarstring(cigar_string)
     ret = cig.query_alignment_offsets()
     assert ret == expected_range
@@ -72,9 +70,7 @@ def test_query_alignment_offsets_failures(cigar_string: str) -> None:
 def test_query_alignment_offsets_reversed(
     cigar_string: str, expected_range: Tuple[int, int]
 ) -> None:
-    """
-    cig.revered().query_alignment_offsets() should return the expected results.
-    """
+    """cig.revered().query_alignment_offsets() should return the expected results."""
     cig = Cigar.from_cigarstring(cigar_string)
 
     ret = cig.reversed().query_alignment_offsets()

--- a/tests/fgpyo/sam/test_clipping.py
+++ b/tests/fgpyo/sam/test_clipping.py
@@ -1,4 +1,4 @@
-"""Tests for :py:mod:`~fgpyo.clipping`"""
+"""Tests for :py:mod:`~fgpyo.clipping`."""
 
 import pytest
 from pysam import AlignedSegment

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -1,4 +1,4 @@
-"""Tests for :py:mod:`~fgpyo.sam`"""
+"""Tests for :py:mod:`~fgpyo.sam`."""
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile as NamedTemp

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -559,7 +559,7 @@ def test_is_not_proper_pair_with_custom_isize_func() -> None:
     builder = SamBuilder()
     r1, r2 = builder.add_pair(chrom="chr1", start1=100, start2=100)
     assert is_proper_pair(r1, r2)
-    assert not is_proper_pair(r1, r2, isize=lambda a, b: False)
+    assert not is_proper_pair(r1, r2, isize=lambda _a, _b: False)
 
 
 def test_isize_when_r2_defined() -> None:

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -74,7 +74,8 @@ def unmapped_sam() -> Path:
 
 @pytest.fixture(scope="function")
 def in_path(request: Any, valid_sam: Path, valid_bam: Path) -> Path:
-    """A fixture for test_sam_file_open_reading to modify in_path prior to executing.
+    """
+    A fixture for test_sam_file_open_reading to modify in_path prior to executing.
 
     Returns:
          the path corresponding to the given file type (i.e. SAM or BAM).
@@ -764,8 +765,10 @@ def test_calc_edit_info_with_clipping_and_deletions() -> None:
 
 @pytest.mark.parametrize("match_htsjdk", [True, False])
 def test_calc_edit_info_with_aligned_Ns(match_htsjdk: bool) -> None:
-    """Ns in query match Ns in reference, but should be counted as mismatches for NM when
-    n_as_match is set to `False`."""
+    """
+    Ns in query match Ns in reference, but should be counted as mismatches for NM when
+    n_as_match is set to `False`.
+    """
     chrom = "ACGTNCGTACNTACGTACGTANNNACGTACACGTACGTACGTACGTACGTACGTACGTAT"
     builder = SamBuilder(r1_len=30)
     rec = builder.add_single(
@@ -792,9 +795,11 @@ def test_calc_edit_info_with_aligned_Ns(match_htsjdk: bool) -> None:
 
 @pytest.mark.parametrize("match_htsjdk", [True, False])
 def test_calc_edit_info_with_consecutive_mismatches(match_htsjdk: bool) -> None:
-    """`htsjdk` testing data with consecutive mismatches and no match to start.
+    """
+    `htsjdk` testing data with consecutive mismatches and no match to start.
 
-    `match_htsjdk` should have no effect."""
+    `match_htsjdk` should have no effect.
+    """
     chrom = "TCGATCGAtcgatcga"
     builder = SamBuilder(r1_len=16)
     rec = builder.add_single(
@@ -859,9 +864,11 @@ def test_calc_edit_info_with_equals_in_query() -> None:
 
 
 def test_calc_edit_info_all_matches() -> None:
-    """Assert that a simple read with all consecutive matches yields expected results.
+    """
+    Assert that a simple read with all consecutive matches yields expected results.
 
-    Read 4 from `htsjdk` testing data."""
+    Read 4 from `htsjdk` testing data.
+    """
     chrom = "TCGATCGAtcgatcga"
     builder = SamBuilder(r1_len=8)
     rec = builder.add_single(

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -18,7 +18,7 @@ import fgpyo.sam as sam
 from fgpyo.sam import Cigar
 from fgpyo.sam import CigarElement
 from fgpyo.sam import CigarOp
-from fgpyo.sam import CigarParsingError
+from fgpyo.sam import CigarParsingException
 from fgpyo.sam import PairOrientation
 from fgpyo.sam import SamFileType
 from fgpyo.sam import is_proper_pair
@@ -235,7 +235,7 @@ def test_cigar_from_cigartuples(cigartuples: List[Tuple[int, int]], cigarstring:
 
 
 def test_cigar_from_cigartuples_malformed() -> None:
-    with pytest.raises(CigarParsingError, match=r".*Malformed cigar tuples.*"):
+    with pytest.raises(CigarParsingException, match=r".*Malformed cigar tuples.*"):
         cigartuples = [(0, 10), (1, 5), (22, 1)]
         Cigar.from_cigartuples(cigartuples)
 
@@ -244,13 +244,13 @@ def test_pretty_cigarstring_exception() -> None:
     cigar = "10M5U4M"
     index = 4
     expected = "10M5[U]4M"
-    with pytest.raises(CigarParsingError, match=r".*Malformed cigar") as ex:
+    with pytest.raises(CigarParsingException, match=r".*Malformed cigar") as ex:
         raise Cigar._pretty_cigarstring_exception(cigar, index)
 
     assert expected in str(ex)
 
     expected = cigar + "[]"
-    with pytest.raises(CigarParsingError, match=r".*Malformed cigar") as ex:
+    with pytest.raises(CigarParsingException, match=r".*Malformed cigar") as ex:
         raise Cigar._pretty_cigarstring_exception(cigar, len(cigar))
     assert expected in str(ex)
 
@@ -271,7 +271,7 @@ def test_from_cigarstring_op_should_start_with_digit() -> None:
     errors = ["", "[M]", "10M[I]", "10M5S[U]"]
     for cigar, error in zip(cigars, errors, strict=True):
         match = "Malformed cigar: " + error if cigar else "Cigar string was empty"
-        with pytest.raises(CigarParsingError) as ex:
+        with pytest.raises(CigarParsingException) as ex:
             Cigar.from_cigarstring(cigar)
         assert match in str(ex)
 
@@ -280,7 +280,7 @@ def test_from_cigarstring_no_length() -> None:
     cigars = ["M", "10MS"]
     errors = ["", "10M[S]"]
     for cigar, error in zip(cigars, errors, strict=True):
-        with pytest.raises(CigarParsingError) as ex:
+        with pytest.raises(CigarParsingException) as ex:
             Cigar.from_cigarstring(cigar)
         assert "Malformed cigar: " + error in str(ex)
 
@@ -289,7 +289,7 @@ def test_from_cigarstring_invalid_operator() -> None:
     cigars = ["10U", "10M5U"]
     errors = ["10[U]", "10M5[U]"]
     for cigar, error in zip(cigars, errors, strict=True):
-        with pytest.raises(CigarParsingError) as ex:
+        with pytest.raises(CigarParsingException) as ex:
             Cigar.from_cigarstring(cigar)
         assert "Malformed cigar: " + error in str(ex)
 
@@ -298,7 +298,7 @@ def test_from_cigarstring_missing_operator() -> None:
     cigars = ["10", "10M5"]
     errors = ["10[]", "10M5[]"]
     for cigar, error in zip(cigars, errors, strict=True):
-        with pytest.raises(CigarParsingError) as ex:
+        with pytest.raises(CigarParsingException) as ex:
             Cigar.from_cigarstring(cigar)
         assert "Malformed cigar: " + error in str(ex)
 

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -764,7 +764,7 @@ def test_calc_edit_info_with_clipping_and_deletions() -> None:
 
 
 @pytest.mark.parametrize("match_htsjdk", [True, False])
-def test_calc_edit_info_with_aligned_Ns(match_htsjdk: bool) -> None:
+def test_calc_edit_info_with_aligned_ns(match_htsjdk: bool) -> None:
     """
     Ns in query match Ns in reference, but should be counted as mismatches for NM when
     n_as_match is set to `False`.

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -765,10 +765,7 @@ def test_calc_edit_info_with_clipping_and_deletions() -> None:
 
 @pytest.mark.parametrize("match_htsjdk", [True, False])
 def test_calc_edit_info_with_aligned_ns(match_htsjdk: bool) -> None:
-    """
-    Ns in query match Ns in reference, but should be counted as mismatches for NM when
-    n_as_match is set to `False`.
-    """
+    """Test that Ns aligned to Ns are counted as mismatches when n_as_match is False."""
     chrom = "ACGTNCGTACNTACGTACGTANNNACGTACACGTACGTACGTACGTACGTACGTACGTAT"
     builder = SamBuilder(r1_len=30)
     rec = builder.add_single(

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -18,7 +18,7 @@ import fgpyo.sam as sam
 from fgpyo.sam import Cigar
 from fgpyo.sam import CigarElement
 from fgpyo.sam import CigarOp
-from fgpyo.sam import CigarParsingException
+from fgpyo.sam import CigarParsingError
 from fgpyo.sam import PairOrientation
 from fgpyo.sam import SamFileType
 from fgpyo.sam import is_proper_pair
@@ -235,7 +235,7 @@ def test_cigar_from_cigartuples(cigartuples: List[Tuple[int, int]], cigarstring:
 
 
 def test_cigar_from_cigartuples_malformed() -> None:
-    with pytest.raises(CigarParsingException, match=r".*Malformed cigar tuples.*"):
+    with pytest.raises(CigarParsingError, match=r".*Malformed cigar tuples.*"):
         cigartuples = [(0, 10), (1, 5), (22, 1)]
         Cigar.from_cigartuples(cigartuples)
 
@@ -244,13 +244,13 @@ def test_pretty_cigarstring_exception() -> None:
     cigar = "10M5U4M"
     index = 4
     expected = "10M5[U]4M"
-    with pytest.raises(CigarParsingException, match=r".*Malformed cigar") as ex:
+    with pytest.raises(CigarParsingError, match=r".*Malformed cigar") as ex:
         raise Cigar._pretty_cigarstring_exception(cigar, index)
 
     assert expected in str(ex)
 
     expected = cigar + "[]"
-    with pytest.raises(CigarParsingException, match=r".*Malformed cigar") as ex:
+    with pytest.raises(CigarParsingError, match=r".*Malformed cigar") as ex:
         raise Cigar._pretty_cigarstring_exception(cigar, len(cigar))
     assert expected in str(ex)
 
@@ -271,7 +271,7 @@ def test_from_cigarstring_op_should_start_with_digit() -> None:
     errors = ["", "[M]", "10M[I]", "10M5S[U]"]
     for cigar, error in zip(cigars, errors, strict=True):
         match = "Malformed cigar: " + error if cigar else "Cigar string was empty"
-        with pytest.raises(CigarParsingException) as ex:
+        with pytest.raises(CigarParsingError) as ex:
             Cigar.from_cigarstring(cigar)
         assert match in str(ex)
 
@@ -280,7 +280,7 @@ def test_from_cigarstring_no_length() -> None:
     cigars = ["M", "10MS"]
     errors = ["", "10M[S]"]
     for cigar, error in zip(cigars, errors, strict=True):
-        with pytest.raises(CigarParsingException) as ex:
+        with pytest.raises(CigarParsingError) as ex:
             Cigar.from_cigarstring(cigar)
         assert "Malformed cigar: " + error in str(ex)
 
@@ -289,7 +289,7 @@ def test_from_cigarstring_invalid_operator() -> None:
     cigars = ["10U", "10M5U"]
     errors = ["10[U]", "10M5[U]"]
     for cigar, error in zip(cigars, errors, strict=True):
-        with pytest.raises(CigarParsingException) as ex:
+        with pytest.raises(CigarParsingError) as ex:
             Cigar.from_cigarstring(cigar)
         assert "Malformed cigar: " + error in str(ex)
 
@@ -298,7 +298,7 @@ def test_from_cigarstring_missing_operator() -> None:
     cigars = ["10", "10M5"]
     errors = ["10[]", "10M5[]"]
     for cigar, error in zip(cigars, errors, strict=True):
-        with pytest.raises(CigarParsingException) as ex:
+        with pytest.raises(CigarParsingError) as ex:
             Cigar.from_cigarstring(cigar)
         assert "Malformed cigar: " + error in str(ex)
 

--- a/tests/fgpyo/sam/test_supplementary_alignments.py
+++ b/tests/fgpyo/sam/test_supplementary_alignments.py
@@ -53,7 +53,6 @@ def test_format_supplementary_alignment() -> None:
 
 def test_from_read() -> None:
     """Test that we can construct a SupplementaryAlignment from an AlignedSegment."""
-
     builder = SamBuilder()
 
     read = builder.add_single()
@@ -73,7 +72,6 @@ def test_from_read() -> None:
 
 def test_end() -> None:
     """Test that we can get the end of a SupplementaryAlignment."""
-
     s1 = SupplementaryAlignment.parse("chr1,123,+,50S100M,60,0")
 
     # NB: the SA tag is one-based, but SupplementaryAlignment is zero-based

--- a/tests/fgpyo/sam/test_template_iterator.py
+++ b/tests/fgpyo/sam/test_template_iterator.py
@@ -108,12 +108,10 @@ def test_write_template(
     tmp_path: Path,
 ) -> None:
     builder = SamBuilder()
-    template = Template.build(
-        [
-            *builder.add_pair(name="r1", chrom="chr1", start1=100, start2=200),
-            builder.add_single(name="r1", chrom="chr1", start=350, supplementary=True),
-        ]
-    )
+    template = Template.build([
+        *builder.add_pair(name="r1", chrom="chr1", start1=100, start2=200),
+        builder.add_single(name="r1", chrom="chr1", start=350, supplementary=True),
+    ])
 
     bam_path = tmp_path / "test.bam"
 
@@ -172,18 +170,16 @@ def test_template_treats_secondary_supplementary_as_supplementary() -> None:
     r1_secondary_supp.is_supplementary = True
     r2_secondary_supp.is_supplementary = True
 
-    actual = Template.build(
-        [
-            r1,
-            r2,
-            r1_secondary,
-            r2_secondary,
-            r1_supp,
-            r2_supp,
-            r1_secondary_supp,
-            r2_secondary_supp,
-        ]
-    )
+    actual = Template.build([
+        r1,
+        r2,
+        r1_secondary,
+        r2_secondary,
+        r1_supp,
+        r2_supp,
+        r1_secondary_supp,
+        r2_secondary_supp,
+    ])
     expected = Template(
         name="x",
         r1=r1,
@@ -248,18 +244,16 @@ def test_template_set_mate_info() -> None:
     r1_secondary_supp.is_supplementary = True
     r2_secondary_supp.is_supplementary = True
 
-    template = Template.build(
-        [
-            r1,
-            r2,
-            r1_secondary,
-            r2_secondary,
-            r1_supp,
-            r2_supp,
-            r1_secondary_supp,
-            r2_secondary_supp,
-        ]
-    )
+    template = Template.build([
+        r1,
+        r2,
+        r1_secondary,
+        r2_secondary,
+        r1_supp,
+        r2_supp,
+        r1_secondary_supp,
+        r2_secondary_supp,
+    ])
 
     template.set_mate_info()
 

--- a/tests/fgpyo/sam/test_template_iterator.py
+++ b/tests/fgpyo/sam/test_template_iterator.py
@@ -196,30 +196,30 @@ def test_set_tag() -> None:
     builder = SamBuilder()
     template = Template.build(builder.add_pair(chrom="chr1", start1=100, start2=200))
 
-    TAG = "XF"
-    VALUE = "value"
+    tag = "XF"
+    value = "value"
 
     for read in template.all_recs():
         with pytest.raises(KeyError):
-            read.get_tag(TAG)
+            read.get_tag(tag)
 
     assert template.r1 is not None and template.r2 is not None  # type narrowing
 
     # test setting
-    template.set_tag(TAG, VALUE)
-    assert template.r1.get_tag(TAG) == VALUE
-    assert template.r2.get_tag(TAG) == VALUE
+    template.set_tag(tag, value)
+    assert template.r1.get_tag(tag) == value
+    assert template.r2.get_tag(tag) == value
 
     # test removal
-    template.set_tag(TAG, None)
+    template.set_tag(tag, None)
     for read in template.all_recs():
         with pytest.raises(KeyError):
-            read.get_tag(TAG)
+            read.get_tag(tag)
 
     # test tags that aren't two characters
     for bad_tag in ["", "A", "ABC", "ABCD"]:
         with pytest.raises(AssertionError, match="Tags must be 2 characters"):
-            template.set_tag(bad_tag, VALUE)
+            template.set_tag(bad_tag, value)
 
 
 def test_template_set_mate_info() -> None:

--- a/tests/fgpyo/test_read_structure.py
+++ b/tests/fgpyo/test_read_structure.py
@@ -7,24 +7,24 @@ from fgpyo.read_structure import ReadStructure
 from fgpyo.read_structure import SegmentType
 
 
-def _T(off: int, len: int) -> ReadSegment:
-    return ReadSegment(offset=off, length=len, kind=SegmentType.Template)
+def _T(off: int, length: int) -> ReadSegment:
+    return ReadSegment(offset=off, length=length, kind=SegmentType.Template)
 
 
-def _B(off: int, len: int) -> ReadSegment:
-    return ReadSegment(offset=off, length=len, kind=SegmentType.SampleBarcode)
+def _B(off: int, length: int) -> ReadSegment:
+    return ReadSegment(offset=off, length=length, kind=SegmentType.SampleBarcode)
 
 
-def _M(off: int, len: int) -> ReadSegment:
-    return ReadSegment(offset=off, length=len, kind=SegmentType.MolecularBarcode)
+def _M(off: int, length: int) -> ReadSegment:
+    return ReadSegment(offset=off, length=length, kind=SegmentType.MolecularBarcode)
 
 
-def _C(off: int, len: int) -> ReadSegment:
-    return ReadSegment(offset=off, length=len, kind=SegmentType.CellBarcode)
+def _C(off: int, length: int) -> ReadSegment:
+    return ReadSegment(offset=off, length=length, kind=SegmentType.CellBarcode)
 
 
-def _S(off: int, len: int) -> ReadSegment:
-    return ReadSegment(offset=off, length=len, kind=SegmentType.Skip)
+def _S(off: int, length: int) -> ReadSegment:
+    return ReadSegment(offset=off, length=length, kind=SegmentType.Skip)
 
 
 @pytest.mark.parametrize(

--- a/tests/fgpyo/test_read_structure.py
+++ b/tests/fgpyo/test_read_structure.py
@@ -7,51 +7,51 @@ from fgpyo.read_structure import ReadStructure
 from fgpyo.read_structure import SegmentType
 
 
-def _T(off: int, length: int) -> ReadSegment:
+def _t(off: int, length: int) -> ReadSegment:
     return ReadSegment(offset=off, length=length, kind=SegmentType.Template)
 
 
-def _B(off: int, length: int) -> ReadSegment:
+def _b(off: int, length: int) -> ReadSegment:
     return ReadSegment(offset=off, length=length, kind=SegmentType.SampleBarcode)
 
 
-def _M(off: int, length: int) -> ReadSegment:
+def _m(off: int, length: int) -> ReadSegment:
     return ReadSegment(offset=off, length=length, kind=SegmentType.MolecularBarcode)
 
 
-def _C(off: int, length: int) -> ReadSegment:
+def _c(off: int, length: int) -> ReadSegment:
     return ReadSegment(offset=off, length=length, kind=SegmentType.CellBarcode)
 
 
-def _S(off: int, length: int) -> ReadSegment:
+def _s(off: int, length: int) -> ReadSegment:
     return ReadSegment(offset=off, length=length, kind=SegmentType.Skip)
 
 
 @pytest.mark.parametrize(
     "string,segments",
     [
-        ("1T", (_T(0, 1),)),
-        ("1B", (_B(0, 1),)),
-        ("1M", (_M(0, 1),)),
-        ("1S", (_S(0, 1),)),
-        ("5C", (_C(0, 5),)),
-        ("101T", (_T(0, 101),)),
+        ("1T", (_t(0, 1),)),
+        ("1B", (_b(0, 1),)),
+        ("1M", (_m(0, 1),)),
+        ("1S", (_s(0, 1),)),
+        ("5C", (_c(0, 5),)),
+        ("101T", (_t(0, 101),)),
         (
             "5B101T",
             (
-                _B(0, 5),
-                _T(5, 101),
+                _b(0, 5),
+                _t(5, 101),
             ),
         ),
-        ("123456789T", (_T(0, 123456789),)),
+        ("123456789T", (_t(0, 123456789),)),
         (
             "10T10B10B10S10M",
             (
-                _T(0, 10),
-                _B(10, 10),
-                _B(20, 10),
-                _S(30, 10),
-                _M(40, 10),
+                _t(0, 10),
+                _b(10, 10),
+                _b(20, 10),
+                _s(30, 10),
+                _m(40, 10),
             ),
         ),
     ],
@@ -66,19 +66,19 @@ def test_read_structure_from_string(string: str, segments: Tuple[ReadSegment, ..
         (
             "75T 8B 8B 75T",
             (
-                _T(0, 75),
-                _B(75, 8),
-                _B(83, 8),
-                _T(91, 75),
+                _t(0, 75),
+                _b(75, 8),
+                _b(83, 8),
+                _t(91, 75),
             ),
         ),
         (
             " 75T  8B   8B     75T  ",
             (
-                _T(0, 75),
-                _B(75, 8),
-                _B(83, 8),
-                _T(91, 75),
+                _t(0, 75),
+                _b(75, 8),
+                _b(83, 8),
+                _t(91, 75),
             ),
         ),
     ],
@@ -92,7 +92,7 @@ def test_read_structure_from_string_with_whitespace(
 @pytest.mark.parametrize(
     "string,segments",
     [
-        ("5M+T", (_M(0, 5), ReadSegment(offset=5, length=None, kind=SegmentType.Template))),
+        ("5M+T", (_m(0, 5), ReadSegment(offset=5, length=None, kind=SegmentType.Template))),
         ("+M", (ReadSegment(offset=0, length=None, kind=SegmentType.MolecularBarcode),)),
     ],
 )
@@ -120,15 +120,15 @@ def test_read_structure_rejects_unknown_type(string: str) -> None:
 @pytest.mark.parametrize(
     "segments,expected",
     [
-        ((_T(4092, 1),), (_T(0, 1),)),
-        ((_B(4092, 1),), (_B(0, 1),)),
-        ((_M(4092, 1),), (_M(0, 1),)),
-        ((_S(4092, 1),), (_S(0, 1),)),
-        ((_T(4092, 101),), (_T(0, 101),)),
-        ((_B(4092, 5), _T(2424, 101)), (_B(0, 5), _T(5, 101))),
+        ((_t(4092, 1),), (_t(0, 1),)),
+        ((_b(4092, 1),), (_b(0, 1),)),
+        ((_m(4092, 1),), (_m(0, 1),)),
+        ((_s(4092, 1),), (_s(0, 1),)),
+        ((_t(4092, 101),), (_t(0, 101),)),
+        ((_b(4092, 5), _t(2424, 101)), (_b(0, 5), _t(5, 101))),
         (
-            (_T(4092, 101), _B(4092, 101), _B(4092, 101), _S(4092, 101), _M(4092, 101)),
-            (_T(0, 101), _B(101, 101), _B(202, 101), _S(303, 101), _M(404, 101)),
+            (_t(4092, 101), _b(4092, 101), _b(4092, 101), _s(4092, 101), _m(4092, 101)),
+            (_t(0, 101), _b(101, 101), _b(202, 101), _s(303, 101), _m(404, 101)),
         ),
     ],
 )
@@ -147,11 +147,11 @@ def test_read_structure_from_invalid_exception(string: str) -> None:
 
 def test_read_structure_collect_segments_of_a_single_kind() -> None:
     rs: ReadStructure = ReadStructure.from_string("10M9T8B7S10M9T8B7S3C")
-    assert rs.template_segments() == (_T(10, 9), _T(44, 9))
-    assert rs.molecular_barcode_segments() == (_M(0, 10), _M(34, 10))
-    assert rs.sample_barcode_segments() == (_B(19, 8), _B(53, 8))
-    assert rs.skip_segments() == (_S(27, 7), _S(61, 7))
-    assert rs.cell_barcode_segments() == (_C(68, 3),)
+    assert rs.template_segments() == (_t(10, 9), _t(44, 9))
+    assert rs.molecular_barcode_segments() == (_m(0, 10), _m(34, 10))
+    assert rs.sample_barcode_segments() == (_b(19, 8), _b(53, 8))
+    assert rs.skip_segments() == (_s(27, 7), _s(61, 7))
+    assert rs.cell_barcode_segments() == (_c(68, 3),)
 
 
 @pytest.mark.parametrize(
@@ -253,19 +253,19 @@ def test_read_structure_length(string: str, length: int) -> None:
 @pytest.mark.parametrize(
     "string,index,segment",
     [
-        ("1T", 0, _T(0, 1)),
-        ("1B", 0, _B(0, 1)),
-        ("1M", 0, _M(0, 1)),
-        ("1S", 0, _S(0, 1)),
-        ("101T", 0, _T(0, 101)),
-        ("5B101T", 0, _B(0, 5)),
-        ("5B101T", 1, _T(5, 101)),
-        ("123456789T", 0, _T(0, 123456789)),
-        ("10T10B10B10S10M", 0, _T(0, 10)),
-        ("10T10B10B10S10M", 1, _B(10, 10)),
-        ("10T10B10B10S10M", 2, _B(20, 10)),
-        ("10T10B10B10S10M", 3, _S(30, 10)),
-        ("10T10B10B10S10M", 4, _M(40, 10)),
+        ("1T", 0, _t(0, 1)),
+        ("1B", 0, _b(0, 1)),
+        ("1M", 0, _m(0, 1)),
+        ("1S", 0, _s(0, 1)),
+        ("101T", 0, _t(0, 101)),
+        ("5B101T", 0, _b(0, 5)),
+        ("5B101T", 1, _t(5, 101)),
+        ("123456789T", 0, _t(0, 123456789)),
+        ("10T10B10B10S10M", 0, _t(0, 10)),
+        ("10T10B10B10S10M", 1, _b(10, 10)),
+        ("10T10B10B10S10M", 2, _b(20, 10)),
+        ("10T10B10B10S10M", 3, _s(30, 10)),
+        ("10T10B10B10S10M", 4, _m(40, 10)),
     ],
 )
 def test_read_structure_index(string: str, index: int, segment: ReadSegment) -> None:

--- a/tests/fgpyo/test_sequence.py
+++ b/tests/fgpyo/test_sequence.py
@@ -1,4 +1,4 @@
-"""Tests for `~fgpyo.sequence`"""
+"""Tests for `~fgpyo.sequence`."""
 
 from typing import List
 from typing import Tuple

--- a/tests/fgpyo/util/test_inspect.py
+++ b/tests/fgpyo/util/test_inspect.py
@@ -23,6 +23,8 @@ from fgpyo.util.inspect import tuple_parser
 
 @attr.s(auto_attribs=True, frozen=True)
 class Name:
+    """Test attr class with various field types."""
+
     required: str
     custom_parser: str
     converted: int = attr.field(converter=int)
@@ -66,16 +68,20 @@ def test_attribute_has_default() -> None:
 
 
 class Foo:
-    pass
+    """Test class used as a field type."""
 
 
 @attr.s(auto_attribs=True, frozen=True)
 class Bar:
+    """Test attr class with a Foo field."""
+
     foo: Foo
 
 
 @dataclasses.dataclass(frozen=True)
 class Baz:
+    """Test dataclass with a Foo field."""
+
     foo: Foo
 
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -33,6 +33,8 @@ from fgpyo.util.metric import _assert_is_metric_class
 
 
 class EnumTest(enum.Enum):
+    """Test enum for metric parsing tests."""
+
     EnumVal1 = "val1"
     EnumVal2 = "val2"
     EnumVal3 = "val3"
@@ -619,6 +621,8 @@ def test_read_header_can_read_empty(tmp_path: Path) -> None:
 
 @dataclass
 class FakeMetric(Metric["FakeMetric"]):
+    """Test metric class for MetricWriter tests."""
+
     foo: str
     bar: int
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -79,6 +79,7 @@ class DataBuilder:
     """
 
     def __init__(self, use_attr: bool) -> None:
+        """Initializes test data using attr or dataclasses based on use_attr."""
         self.use_attr = use_attr
 
         @make_dataclass(use_attr=use_attr)

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -42,7 +42,7 @@ T = TypeVar("T", bound=Type)
 
 
 def make_dataclass(use_attr: bool = False) -> Callable[[T], T]:
-    """Decorator to make a attr- or dataclasses-style dataclass"""
+    """Decorator to make a attr- or dataclasses-style dataclass."""
     sys.stderr.write(f"use_attr = {use_attr}\n")
     if use_attr:
 
@@ -228,7 +228,7 @@ num_metrics = len(attr_data_and_classes.DUMMY_METRICS)
 def test_is_correct_dataclass_type(use_attr: bool) -> None:
     """
     Test that the DataBuilder class works as expected, as do the is_attr_class and
-    is_dataclasses_class methods
+    is_dataclasses_class methods.
     """
     data_and_classes = DataBuilder(use_attr=use_attr)
     assert use_attr == data_and_classes.use_attr
@@ -586,9 +586,7 @@ def test_metric_columns_out_of_order(tmp_path: Path, data_and_classes: DataBuild
 
 
 def test_read_header_can_read_picard(tmp_path: Path) -> None:
-    """
-    Test that we can read the header of a picard-formatted file.
-    """
+    """Test that we can read the header of a picard-formatted file."""
     metrics_path = tmp_path / "fake_picard_metrics"
 
     with metrics_path.open("w") as metrics_file:
@@ -607,9 +605,7 @@ def test_read_header_can_read_picard(tmp_path: Path) -> None:
 
 
 def test_read_header_can_read_empty(tmp_path: Path) -> None:
-    """
-    If the input file is empty, we should get an empty header.
-    """
+    """If the input file is empty, we should get an empty header."""
     metrics_path = tmp_path / "empty"
     metrics_path.touch()
 
@@ -831,9 +827,7 @@ def test_writer_raises_if_fifo(capsys: CaptureFixture) -> None:
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_assert_is_metric_class(data_and_classes: DataBuilder) -> None:
-    """
-    Test that we can validate if a class is a Metric.
-    """
+    """Test that we can validate if a class is a Metric."""
     _assert_is_metric_class(data_and_classes.DummyMetric)
 
 
@@ -909,18 +903,14 @@ def test_assert_fieldnames_are_metric_attributes_raises(
     data_and_classes: DataBuilder,
     fieldnames: List[str],
 ) -> None:
-    """
-    Should raise an error if any of the provided fieldnames are not an attribute on the metric.
-    """
+    """Should raise an error if any of the provided fieldnames are not an attribute on the metric."""
     with pytest.raises(ValueError, match="One or more of the specified fields are not "):
         _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_assert_file_header_matches_metric(tmp_path: Path, data_and_classes: DataBuilder) -> None:
-    """
-    Should not raise an error if the provided file header matches the provided metric.
-    """
+    """Should not raise an error if the provided file header matches the provided metric."""
     metric_path = tmp_path / "metrics.tsv"
     with metric_path.open("w") as metrics_file:
         metrics_file.write("name\tage\n")
@@ -940,9 +930,7 @@ def test_assert_file_header_matches_metric(tmp_path: Path, data_and_classes: Dat
 def test_assert_file_header_matches_metric_raises(
     tmp_path: Path, data_and_classes: DataBuilder, header: List[str]
 ) -> None:
-    """
-    Should raise an error if the provided file header does not match the provided metric.
-    """
+    """Should raise an error if the provided file header does not match the provided metric."""
     metric_path = tmp_path / "metrics.tsv"
     with metric_path.open("w") as metrics_file:
         metrics_file.write("\t".join(header) + "\n")

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -496,9 +496,10 @@ def test_metric_formatted_values_with_empty_string(data_and_classes: DataBuilder
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_list_format(data_and_classes: DataBuilder) -> None:
-    assert data_and_classes.ListPerson(name=["Max", "Sally"], age=[43, 55]).formatted_values() == (
-        ["Max,Sally", "43,55"]
-    )
+    assert data_and_classes.ListPerson(name=["Max", "Sally"], age=[43, 55]).formatted_values() == ([
+        "Max,Sally",
+        "43,55",
+    ])
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
@@ -512,15 +513,18 @@ def test_metric_list_parse(data_and_classes: DataBuilder) -> None:
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metric_list_format_with_empty_string(data_and_classes: DataBuilder) -> None:
     ListPerson: TypeAlias = data_and_classes.ListPerson
-    assert ListPerson(name=[None, "Sally"], age=[43, 55]).formatted_values() == (
-        [",Sally", "43,55"]
-    )
-    assert ListPerson(name=[None, "Sally"], age=[None, 55]).formatted_values() == (
-        [",Sally", ",55"]
-    )
-    assert ListPerson(name=["Max", "Sally"], age=[None, None]).formatted_values() == (
-        ["Max,Sally", ","]
-    )
+    assert ListPerson(name=[None, "Sally"], age=[43, 55]).formatted_values() == ([
+        ",Sally",
+        "43,55",
+    ])
+    assert ListPerson(name=[None, "Sally"], age=[None, 55]).formatted_values() == ([
+        ",Sally",
+        ",55",
+    ])
+    assert ListPerson(name=["Max", "Sally"], age=[None, None]).formatted_values() == ([
+        "Max,Sally",
+        ",",
+    ])
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -903,7 +903,7 @@ def test_assert_fieldnames_are_metric_attributes_raises(
     data_and_classes: DataBuilder,
     fieldnames: List[str],
 ) -> None:
-    """Should raise an error if any of the provided fieldnames are not an attribute on the metric."""
+    """Should raise an error if any fieldnames are not an attribute on the metric."""
     with pytest.raises(ValueError, match="One or more of the specified fields are not "):
         _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -302,7 +302,7 @@ def test_metrics_roundtrip(tmp_path: Path, data_and_classes: DataBuilder) -> Non
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))
 def test_metrics_roundtrip_gzip(tmp_path: Path, data_and_classes: DataBuilder) -> None:
     path: Path = Path(tmp_path) / "metrics.txt.gz"
-    DummyMetric: Type[Metric] = data_and_classes.DummyMetric
+    DummyMetric: TypeAlias = data_and_classes.DummyMetric
 
     DummyMetric.write(path, *data_and_classes.DUMMY_METRICS)
 
@@ -553,22 +553,22 @@ def test_metrics_fast_concat(tmp_path: Path, data_and_classes: DataBuilder) -> N
     ]
     path_output: Path = tmp_path / "metrics_concat.txt"
     DummyMetric: TypeAlias = data_and_classes.DummyMetric
-    DUMMY_METRICS: list[DummyMetric] = data_and_classes.DUMMY_METRICS
+    dummy_metrics: list[DummyMetric] = data_and_classes.DUMMY_METRICS
 
-    DummyMetric.write(path_input[0], DUMMY_METRICS[0])
-    DummyMetric.write(path_input[1], DUMMY_METRICS[1])
-    DummyMetric.write(path_input[2], DUMMY_METRICS[2])
+    DummyMetric.write(path_input[0], dummy_metrics[0])
+    DummyMetric.write(path_input[1], dummy_metrics[1])
+    DummyMetric.write(path_input[2], dummy_metrics[2])
 
     Metric.fast_concat(*path_input, output=path_output)
     metrics: List[DummyMetric] = list(DummyMetric.read(path=path_output))
 
-    assert len(metrics) == len(DUMMY_METRICS)
+    assert len(metrics) == len(dummy_metrics)
     assert metrics[0].header() == DummyMetric.header()
     assert metrics[1].header() == DummyMetric.header()
     assert metrics[2].header() == DummyMetric.header()
-    assert metrics[0] == DUMMY_METRICS[0]
-    assert metrics[1] == DUMMY_METRICS[1]
-    assert metrics[2] == DUMMY_METRICS[2]
+    assert metrics[0] == dummy_metrics[0]
+    assert metrics[1] == dummy_metrics[1]
+    assert metrics[2] == dummy_metrics[2]
 
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -62,10 +62,11 @@ def make_dataclass(use_attr: bool = False) -> Callable[[T], T]:
 
 class DataBuilder:
     """
-    Holds classes and data for testing, either using attr- or dataclasses-style dataclass
-    We need to run each test both with attr and dataclasses classes, so use this class to construct
-    the test metrics appropriately, governed by the use_attr flag. After construction, the
-    DataBuilder object will have all the required Metrics:
+    Holds classes and data for testing, either using attr- or dataclasses-style dataclass.
+
+    We need to run each test both with attr and dataclasses classes, so use this class to
+    construct the test metrics appropriately, governed by the use_attr flag. After construction,
+    the DataBuilder object will have all the required Metrics:
 
     Attributes:
         use_attr: If True use attr classes for Metrics, if False use dataclasses
@@ -229,10 +230,7 @@ num_metrics = len(attr_data_and_classes.DUMMY_METRICS)
 
 @pytest.mark.parametrize("use_attr", [False, True])
 def test_is_correct_dataclass_type(use_attr: bool) -> None:
-    """
-    Test that the DataBuilder class works as expected, as do the is_attr_class and
-    is_dataclasses_class methods.
-    """
+    """Test that DataBuilder, is_attr_class, and is_dataclasses_class work as expected."""
     data_and_classes = DataBuilder(use_attr=use_attr)
     assert use_attr == data_and_classes.use_attr
     assert is_attr_class(data_and_classes.DummyMetric) is use_attr
@@ -732,10 +730,7 @@ def test_writer_append_raises_if_no_header(tmp_path: Path) -> None:
 
 
 def test_writer_append_raises_if_header_does_not_match(tmp_path: Path) -> None:
-    """
-    Test that we raise an error if we try to append to a file whose header doesn't match our
-    dataclass.
-    """
+    """Test that appending to a file whose header doesn't match our dataclass raises an error."""
     fpath = tmp_path / "test.txt"
 
     with fpath.open("w") as fout:
@@ -837,10 +832,7 @@ def test_assert_is_metric_class(data_and_classes: DataBuilder) -> None:
 
 
 def test_assert_is_metric_class_raises_if_not_decorated() -> None:
-    """
-    Test that we raise an error if the provided type is a Metric subclass but not decorated as a
-    dataclass or attr.
-    """
+    """Test that a Metric subclass not decorated as a dataclass or attr raises an error."""
 
     class BadMetric(Metric["BadMetric"]):
         foo: str
@@ -851,10 +843,7 @@ def test_assert_is_metric_class_raises_if_not_decorated() -> None:
 
 
 def test_assert_is_metric_class_raises_if_not_a_metric() -> None:
-    """
-    Test that we raise an error if the provided type is decorated as a
-    dataclass or attr but does not subclass Metric.
-    """
+    """Test that a dataclass or attr class not subclassing Metric raises an error."""
 
     @dataclass
     class BadMetric:
@@ -888,10 +877,7 @@ def test_assert_fieldnames_are_metric_attributes(
     data_and_classes: DataBuilder,
     fieldnames: List[str],
 ) -> None:
-    """
-    Should not raise an error if the provided fieldnames are all attributes of
-    the provided metric.
-    """
+    """Should not raise an error if the provided fieldnames are all metric attributes."""
     _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
 
 @pytest.mark.parametrize("data_and_classes", (attr_data_and_classes, dataclasses_data_and_classes))

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -589,7 +589,6 @@ def test_read_header_can_read_picard(tmp_path: Path) -> None:
     """
     Test that we can read the header of a picard-formatted file.
     """
-
     metrics_path = tmp_path / "fake_picard_metrics"
 
     with metrics_path.open("w") as metrics_file:
@@ -611,7 +610,6 @@ def test_read_header_can_read_empty(tmp_path: Path) -> None:
     """
     If the input file is empty, we should get an empty header.
     """
-
     metrics_path = tmp_path / "empty"
     metrics_path.touch()
 
@@ -797,7 +795,6 @@ def test_writer_include_fields_reorders(tmp_path: Path) -> None:
 
 def test_writer_exclude_fields(tmp_path: Path) -> None:
     """Test that we can exclude fields from being written."""
-
     fpath = tmp_path / "test.txt"
 
     data = [

--- a/tests/fgpyo/vcf/test_builder.py
+++ b/tests/fgpyo/vcf/test_builder.py
@@ -53,9 +53,7 @@ def _get_random_variant_inputs(
     random_generator: random.Random,
     sequence_dict: Dict[str, Dict[str, Any]],
 ) -> Mapping[str, Any]:
-    """
-    Randomly generate inputs that should produce a valid Variant. Don't include format fields.
-    """
+    """Randomly generate inputs that should produce a valid Variant. Don't include format fields."""
     contig, contig_len = _get_random_contig(random_generator, sequence_dict)
     variant_reference_len = random_generator.choice([0, 1, 5, 100])
     variant_read_len = random_generator.choice(

--- a/tests/fgpyo/vcf/test_builder.py
+++ b/tests/fgpyo/vcf/test_builder.py
@@ -102,7 +102,8 @@ def zero_sample_record_inputs(
     random_generator: random.Random, sequence_dict: Dict[str, Dict[str, Any]]
 ) -> Tuple[Mapping[str, Any], ...]:
     """
-    Fixture with inputs to create test Variant records for zero-sample VCFs (no genotypes).
+    Fixture with inputs to create test Variant records for zero-sample VCFs.
+
     Make them MappingProxyType so that they are immutable.
     """
     return tuple(_get_random_variant_inputs(random_generator, sequence_dict) for _ in range(100))
@@ -267,10 +268,7 @@ def test_zero_sample_vcf_round_trip(
     zero_sample_record_inputs: Tuple[Mapping[str, Any], ...],
     compress: bool,
 ) -> None:
-    """
-    Test if zero-sample VCF (no genotypes) output records match the records read in from the
-    resulting VCF.
-    """
+    """Test if zero-sample VCF output records match the records read from the resulting VCF."""
     vcf = temp_path / ("test.vcf.gz" if compress else "test.vcf")
     variant_builder = VariantBuilder()
     _add_headers(variant_builder)
@@ -344,8 +342,9 @@ def test_variant_sample_records_match_inputs(
 ) -> None:
     """
     Test if records with samples / genotypes match the requested inputs.
-    If add_genotypes is True, then add random genotypes to the record input, otherwise test that
-    the VariantBuilder will work even if genotypes are not supplied.
+
+    If add_genotypes is True, then add random genotypes to the record input, otherwise test
+    that the VariantBuilder will work even if genotypes are not supplied.
     """
     sample_ids = [f"sample{i}" for i in range(num_samples)]
     variant_builder = VariantBuilder(sample_ids=sample_ids)
@@ -384,9 +383,10 @@ def test_variant_sample_vcf_round_trip(
     add_genotypes_to_records: bool,
 ) -> None:
     """
-    Test if 1 or multi-sample VCF output records match the records read in from the resulting VCF.
-    If add_genotypes is True, then add random genotypes to the record input, otherwise test that
-    the VariantBuilder will work even if genotypes are not supplied.
+    Test if multi-sample VCF output records match the records read from the resulting VCF.
+
+    If add_genotypes is True, then add random genotypes to the record input, otherwise test
+    that the VariantBuilder will work even if genotypes are not supplied.
     """
     sample_ids = [f"sample{i}" for i in range(num_samples)]
     vcf = temp_path / ("test.vcf.gz" if compress else "test.vcf")

--- a/tests/fgpyo/vcf/test_builder.py
+++ b/tests/fgpyo/vcf/test_builder.py
@@ -42,13 +42,11 @@ def _get_random_contig(
 
 
 _ALL_FILTERS = frozenset({"MAYBE", "FAIL", "SOMETHING"})
-_INFO_FIELD_TYPES = MappingProxyType(
-    {
-        "TEST_INT": VcfFieldType.INTEGER,
-        "TEST_STR": VcfFieldType.STRING,
-        "TEST_FLOAT": VcfFieldType.FLOAT,
-    }
-)
+_INFO_FIELD_TYPES = MappingProxyType({
+    "TEST_INT": VcfFieldType.INTEGER,
+    "TEST_STR": VcfFieldType.STRING,
+    "TEST_FLOAT": VcfFieldType.FLOAT,
+})
 
 
 def _get_random_variant_inputs(
@@ -91,16 +89,14 @@ def _get_random_variant_inputs(
         for key, value_type in _INFO_FIELD_TYPES.items()
     }
 
-    return MappingProxyType(
-        {
-            "contig": contig,
-            "pos": start,
-            "ref": ref,
-            "alts": (alt,),
-            "filter": filter,
-            "info": info,
-        }
-    )
+    return MappingProxyType({
+        "contig": contig,
+        "pos": start,
+        "ref": ref,
+        "alts": (alt,),
+        "filter": filter,
+        "info": info,
+    })
 
 
 @pytest.fixture(scope="function")
@@ -324,18 +320,16 @@ def _add_random_genotypes(
     """Add random genotypes to the record input."""
     genotypes = {
         sample_id: {
-            "GT": random_generator.choice(
-                [
-                    (None,),
-                    (0, 0),
-                    (0, 1),
-                    (1, 0),
-                    (1, 1),
-                    (None, 0),
-                    (0, None),
-                    (1, None),
-                ]
-            )
+            "GT": random_generator.choice([
+                (None,),
+                (0, 0),
+                (0, 1),
+                (1, 0),
+                (1, 1),
+                (None, 0),
+                (0, None),
+                (1, None),
+            ])
         }
         for sample_id in sample_ids
     }

--- a/tests/fgpyo/vcf/test_builder.py
+++ b/tests/fgpyo/vcf/test_builder.py
@@ -60,7 +60,7 @@ def _get_random_variant_inputs(
         [1, 5, 100] if variant_reference_len == 0 else [0, 1, 5, 100]
     )
     num_filters = random_generator.randint(0, 3)
-    filter = tuple(random_generator.sample(list(_ALL_FILTERS), k=num_filters))
+    filters = tuple(random_generator.sample(list(_ALL_FILTERS), k=num_filters))
     start = random_generator.randint(1, contig_len - variant_reference_len)
     # stop is not directly passed by current API, but this is what its value would be:
     # stop = start + variant_reference_len
@@ -92,7 +92,7 @@ def _get_random_variant_inputs(
         "pos": start,
         "ref": ref,
         "alts": (alt,),
-        "filter": filter,
+        "filter": filters,
         "info": info,
     })
 
@@ -110,8 +110,8 @@ def zero_sample_record_inputs(
 
 def _add_headers(variant_builder: VariantBuilder) -> None:
     """Add needed headers to the VariantBuilder."""
-    for filter in _ALL_FILTERS:
-        variant_builder.add_filter_header(filter)
+    for filter_name in _ALL_FILTERS:
+        variant_builder.add_filter_header(filter_name)
     for field_name, field_type in _INFO_FIELD_TYPES.items():
         variant_builder.add_info_header(field_name, field_type=field_type)
 


### PR DESCRIPTION
## Summary
- Adds ruff configuration (formatter + linter) sourced from our [Python package template](https://github.com/fulcrumgenomics/python_template), with rules for pycodestyle, pyflakes, pydocstyle (Google convention), isort, PEP 8 naming, bugbear, flake8-quotes, builtin shadowing, unused arguments, and McCabe complexity
- Resolves all existing lint violations across the codebase (~180 total), organized as one commit per violation type for reviewability
- Adds `noqa` comments for intentional suppressions (builtin-shadowing in pysam API params, exception names without `Error` suffix)

## Changes by lint rule

| Rule | Count | Fix |
|------|-------|-----|
| D205 | 61 | Insert blank line between docstring summary and description |
| D105 | 31 | Add docstrings to magic methods |
| D102 | 14 | Add docstrings to public methods |
| A001/A002 | 17 | Rename variables/params shadowing builtins (`input` → `input_dir`, `len` → `length`, `format` → `log_format`, etc.) |
| D101 | 11 | Add docstrings to public classes |
| N802 | 10 | Lowercase test function names (`test_overrides_FastaBuilder` → `test_overrides_fasta_builder`) |
| D107 | 8 | Add docstrings to `__init__` methods |
| ARG001/ARG005 | 8 | Prefix unused arguments with `_` |
| N806 | 6 | Lowercase local variables (`N`/`M` → `n`/`m`, `TAG` → `tag`) |
| E501 | 3 | Shorten lines exceeding 100 characters |
| D417 | 3 | Add missing argument descriptions in docstrings |
| D103 | 2 | Add docstrings to public functions |
| N812 | 1 | Rename import alias `PysamWriter` → `pysam_writer` |

## Intentional suppressions (`noqa`)

| Rule | Location | Reason |
|------|----------|--------|
| A002 | `VariantBuilder.add(id=, filter=)` | Matches pysam's API |
| A001 | `VariantBuilder.add` body | Re-assignment of `filter` param |
| N818 | `CigarParsingException`, `ParserNotFoundException`, `InspectException` | Renaming is a breaking API change |

## Test plan
- [x] `uv run poe check-tests` — 810 tests pass
- [x] `uv run poe check-doctests` — 17 doctests pass
- [x] `uv run ruff check` — 0 violations (6 suppressed with `noqa`)
- [x] `uv run ruff format --check` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)