### PR TITLE
chore: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/publish_fgpyo.yml
+++ b/.github/workflows/publish_fgpyo.yml
@@ -17,11 +17,12 @@ jobs:
         shell: bash
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: rickstaa/action-contains-tag@v1
+      - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308  # v1.2.10
         id: contains_tag
         with:
           reference: "main"
@@ -43,21 +44,22 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.12
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Build package
         run: uv build --sdist --out-dir dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: fgpyo-sdist
           path: dist/*.tar.gz
@@ -69,13 +71,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: packages
           pattern: 'fgpyo-*'
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: packages/
           skip-existing: true
@@ -88,13 +90,13 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Generate a Changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72  # v4.7.1
         id: git-cliff
         with:
           config: pyproject.toml
@@ -112,7 +114,7 @@ jobs:
     steps:
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           name: ${{ github.ref_name }}
           body: ${{ needs.make-changelog.outputs.release_body }}

--- a/.github/workflows/readthedocs.yml
+++ b/.github/workflows/readthedocs.yml
@@ -15,6 +15,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@31a30360a2d7530806bff6855aa209167f06a89c  # latest commit on main (action deprecated, no releases)
+      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333  # v1.5 (deprecated)
         with:
           project-slug: "fgpyo"

--- a/.github/workflows/readthedocs.yml
+++ b/.github/workflows/readthedocs.yml
@@ -15,6 +15,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@31a30360a2d7530806bff6855aa209167f06a89c  # latest commit on main (action deprecated, no releases)
         with:
           project-slug: "fgpyo"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
         PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: "${{ matrix.PYTHON_VERSION }}"
@@ -47,6 +47,6 @@ jobs:
           uv run poe build-docs
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: "${{ matrix.PYTHON_VERSION }}"
@@ -33,7 +33,7 @@ jobs:
           uv build --wheel -o wheelhouse
 
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: fgpyo-wheels-${{ matrix.PYTHON_VERSION }}
           path: ./wheelhouse/fgpyo*.whl


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to full commit SHA hashes across all workflows
  (`tests.yml`, `wheels.yml`, `publish_fgpyo.yml`, `readthedocs.yml`)
- Update previously-pinned actions to their latest versions
  (e.g. checkout v5 → v6, setup-uv v6 → v8, codecov v5 → v6)

This follows GitHub's security best practice of pinning third-party actions to
immutable commit SHAs rather than mutable version tags.

## Note on readthedocs

The `readthedocs/actions/preview` action used in `readthedocs.yml` is
deprecated. From the [repository README](https://github.com/readthedocs/actions):

> **This action is deprecated and it shouldn't be used.** This feature was
> included in the Read the Docs application itself.

I've pinned it to the latest commit on main for now, but it should be replaced
with the built-in Read the Docs PR build integration described here:

https://docs.readthedocs.com/platform/stable/visual-diff.html#show-build-overview-in-pull-requests

I've opened #283 for that — happy to tackle it in a follow-up if you'd like.

## Test plan

- [ ] Verify CI passes on this PR (tests, wheels, publish dry-run)
- [ ] Confirm action versions resolve correctly from pinned SHAs


🤖 Generated with [Claude Code](https://claude.com/claude-code)