### PR TITLE
refactor: use ReadSegment.length over .fixed_length in hot paths

### DIFF
--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -224,7 +224,7 @@ class ReadStructure(Iterable[ReadSegment]):
     @property
     def _min_length(self) -> int:
         """The minimum length read that this read structure can process."""
-        return sum(segment.fixed_length for segment in self.segments if segment.has_fixed_length)
+        return sum(segment.length for segment in self.segments if segment.has_fixed_length)  # type: ignore[misc]
 
     @property
     def has_fixed_length(self) -> bool:
@@ -321,7 +321,7 @@ class ReadStructure(Iterable[ReadSegment]):
             segs = []
             for seg in segments:
                 seg = attr.evolve(seg, offset=off)
-                off += seg.fixed_length if seg.has_fixed_length else 0
+                off += seg.length if seg.has_fixed_length else 0  # type: ignore[operator]
 
                 segs.append(seg)
             segments = tuple(segs)


### PR DESCRIPTION
## Summary

- Reverts two callsites in `fgpyo/read_structure.py` from `segment.fixed_length` back to `segment.length` with a narrow `# type: ignore`.
- `fixed_length` re-runs `has_fixed_length` and re-asserts non-None; at callsites already guarded by `has_fixed_length`, this is redundant work. The previous form (pre-#259) avoided that.
- Addresses Nils' post-merge feedback on #259.

## Test plan

- [x] `uv run poe fix-and-check-all` passes (format, lint, mypy, pytest, doctest)
- [x] `tests/fgpyo/test_read_structure.py` — 60 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)