### PR TITLE
fix: accept file handles and close VariantFile on exception

### DIFF
--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -105,6 +105,8 @@ def writer(path: VcfPath, header: VariantHeader) -> Generator[VcfWriter, None, N
         header: the source for the output VCF header. If you are modifying a VCF file that you are
                 reading from, you can pass reader.header
     """
+    if not isinstance(path, (str, Path, io.IOBase)):
+        raise TypeError(f"Cannot open '{type(path)}' for VCF writing.")
     # Convert Path to str such that pysam will autodetect to write as a gzipped file if provided
     # with a .vcf.gz suffix.
     if isinstance(path, Path):

--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -58,10 +58,10 @@ in coordinate sorted order via the
 
 """
 
+import io
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
-from typing import TextIO
 
 from pysam import VariantFile
 from pysam import VariantFile as VcfReader
@@ -71,7 +71,7 @@ from pysam import VariantHeader
 import fgpyo.io
 
 """The valid base classes for opening a VCF file."""
-VcfPath = Path | str | TextIO
+VcfPath = Path | str | io.IOBase
 
 
 @contextmanager
@@ -82,16 +82,17 @@ def reader(path: VcfPath) -> Generator[VcfReader, None, None]:
     Args:
         path: the path to a VCF, or an open file handle
     """
-    if isinstance(path, (str, Path, TextIO)):
-        with fgpyo.io.suppress_stderr():
-            # to avoid spamming log about index older than vcf, redirect stderr to /dev/null: only
-            # when first opening the file
-            _reader = VariantFile(path, mode="r")  # type: ignore[arg-type]
-        # now stderr is back, so any later stderr messages will go through
-        yield _reader
-        _reader.close()
-    else:
+    if not isinstance(path, (str, Path, io.IOBase)):
         raise TypeError(f"Cannot open '{type(path)}' for VCF reading.")
+    with fgpyo.io.suppress_stderr():
+        # to avoid spamming log about index older than vcf, redirect stderr to /dev/null: only
+        # when first opening the file
+        _reader = VariantFile(path, mode="r")  # type: ignore[arg-type]
+    # now stderr is back, so any later stderr messages will go through
+    try:
+        yield _reader
+    finally:
+        _reader.close()
 
 
 @contextmanager
@@ -109,5 +110,7 @@ def writer(path: VcfPath, header: VariantHeader) -> Generator[VcfWriter, None, N
     if isinstance(path, Path):
         path = str(path)
     _writer = VariantFile(path, header=header, mode="w")
-    yield _writer
-    _writer.close()
+    try:
+        yield _writer
+    finally:
+        _writer.close()

--- a/tests/fgpyo/vcf/test_io.py
+++ b/tests/fgpyo/vcf/test_io.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from fgpyo.vcf import reader as vcf_reader
+from fgpyo.vcf import writer as vcf_writer
+from fgpyo.vcf.builder import VariantBuilder
+
+
+@pytest.fixture(scope="function")
+def vcf_path(tmp_path: Path) -> Path:
+    builder = VariantBuilder()
+    builder.add()
+    return builder.to_path(path=tmp_path / "test.vcf.gz")
+
+
+def test_reader_closes_on_exception(vcf_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="boom"):
+        with vcf_reader(vcf_path) as r:
+            raise RuntimeError("boom")
+    assert r.closed is True
+
+
+def test_writer_closes_on_exception(tmp_path: Path) -> None:
+    header = VariantBuilder().header
+    out = tmp_path / "out.vcf"
+    with pytest.raises(RuntimeError, match="boom"):
+        with vcf_writer(out, header=header) as w:
+            raise RuntimeError("boom")
+    assert w.closed is True
+
+
+def test_reader_accepts_file_handle(vcf_path: Path) -> None:
+    with open(vcf_path, "rb") as handle:
+        with vcf_reader(handle) as r:
+            records = list(r)
+    assert len(records) == 1
+
+
+def test_reader_rejects_non_path_non_handle() -> None:
+    with pytest.raises(TypeError, match="Cannot open"):
+        with vcf_reader(123):  # type: ignore[arg-type]
+            pass

--- a/tests/fgpyo/vcf/test_io.py
+++ b/tests/fgpyo/vcf/test_io.py
@@ -41,3 +41,10 @@ def test_reader_rejects_non_path_non_handle() -> None:
     with pytest.raises(TypeError, match="Cannot open"):
         with vcf_reader(123):  # type: ignore[arg-type]
             pass
+
+
+def test_writer_rejects_non_path_non_handle() -> None:
+    header = VariantBuilder().header
+    with pytest.raises(TypeError, match="Cannot open"):
+        with vcf_writer(123, header=header):  # type: ignore[arg-type]
+            pass


### PR DESCRIPTION
## Summary

Fixes #288

`fgpyo.vcf.reader` / `writer` had two correctness bugs. The runtime `isinstance(path, typing.TextIO)` check never matched real file objects — `typing.TextIO` is an annotation alias, so the documented "open file handle" input was unreachable and raised `TypeError`. And `yield` was not wrapped in `try/finally`, so if the caller's `with` block raised, the underlying `pysam.VariantFile` leaked.

Swap `typing.TextIO` for `io.IOBase` in the isinstance check and the `VcfPath` alias, and wrap `yield` in `try/finally` in both `reader()` and `writer()`.

## Test plan

- New `tests/fgpyo/vcf/test_io.py` covers: raising inside `with reader(...)` / `with writer(...)` closes the `VariantFile`; passing a real `open(path, "rb")` handle to `reader()` now yields records; passing a non-path non-handle still raises `TypeError`.
- Full `tests/fgpyo/vcf/` suite, mypy, and ruff all clean.