### PR TITLE
fix: `copy_umi_from_read_name` delimiter for multi-UMI read names

### DIFF
--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -87,17 +87,28 @@ def extract_umis_from_read_name(
 
 
 def copy_umi_from_read_name(
-    rec: AlignedSegment, strict: bool = False, remove_umi: bool = False
+    rec: AlignedSegment,
+    strict: bool = False,
+    remove_umi: bool = False,
+    read_name_delimiter: str = _ILLUMINA_READ_NAME_DELIMITER,
+    umi_delimiter: str = _ILLUMINA_UMI_DELIMITER,
 ) -> bool:
     """
     Copy a UMI from an alignment's read name to its `RX` SAM tag.
 
     The UMI will not be copied to RX tag if it is invalid.
 
+    `strict`, `read_name_delimiter`, and `umi_delimiter` are forwarded to
+    [`extract_umis_from_read_name`][fgpyo.platform.illumina.extract_umis_from_read_name] — see
+    that function for their semantics.
+
     Args:
         rec: The alignment record to update.
-        strict: If `True` and UMI invalid, will throw an exception
+        strict: If `True` and UMI invalid, will throw an exception.
         remove_umi: If `True`, the UMI will be removed from the read name after copying.
+        read_name_delimiter: The delimiter separating the components of the read name.
+            Also used to strip the UMI segment when `remove_umi` is `True`.
+        umi_delimiter: The delimiter separating multiple UMIs.
 
     Returns:
         `True` if the UMI was successfully extracted, False if otherwise.
@@ -106,18 +117,21 @@ def copy_umi_from_read_name(
         ValueError: If the read name does not end with a valid UMI.
         ValueError: If the record already has a populated `RX` SAM tag.
     """
+    # NB: Keep the signature of this function in sync with `extract_umis_from_read_name`.
     assert rec.query_name is not None, "Alignment record must have a query name"
 
     umi = extract_umis_from_read_name(
         read_name=rec.query_name,
         strict=strict,
+        read_name_delimiter=read_name_delimiter,
+        umi_delimiter=umi_delimiter,
     )
     if umi is not None:
         if rec.has_tag("RX"):
             raise ValueError(f"Record {rec.query_name} already has a populated RX tag")
         rec.set_tag(tag="RX", value=umi)
         if remove_umi:
-            last_index = rec.query_name.rfind(_ILLUMINA_READ_NAME_DELIMITER)
+            last_index = rec.query_name.rfind(read_name_delimiter)
             rec.query_name = rec.query_name[:last_index] if last_index != -1 else rec.query_name
         return True
     elif strict:

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -111,7 +111,6 @@ def copy_umi_from_read_name(
     umi = extract_umis_from_read_name(
         read_name=rec.query_name,
         strict=strict,
-        umi_delimiter=_ILLUMINA_READ_NAME_DELIMITER,
     )
     if umi is not None:
         if rec.has_tag("RX"):

--- a/tests/fgpyo/platform/test_illumina.py
+++ b/tests/fgpyo/platform/test_illumina.py
@@ -109,17 +109,44 @@ def test_strict_extract_umi_from_read_name(read_name: str, extraction: str) -> N
     assert extract_umis_from_read_name(read_name, strict=True) == extraction
 
 
-@pytest.mark.parametrize("remove_umi, strict", [[True, False], [True, False]])
-def test_copy_valid_umi_from_read_name(remove_umi: bool, strict: bool) -> None:
+@pytest.mark.parametrize(
+    "raw_umi, expected_umi",
+    [
+        ("GATTACA", "GATTACA"),
+        ("AAAA+TTTT", "AAAA-TTTT"),
+    ],
+)
+@pytest.mark.parametrize("remove_umi", [True, False])
+@pytest.mark.parametrize("strict", [True, False])
+def test_copy_valid_umi_from_read_name(
+    raw_umi: str, expected_umi: str, remove_umi: bool, strict: bool
+) -> None:
     """Test that we populate the RX field with a valid UMI based on remove_umi and strict."""
     builder = SamBuilder()
-    read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:GATTACA")
+    read = builder.add_single(name=f"abc:def:ghi:jfk:lmn:opq:rst:{raw_umi}")
     assert copy_umi_from_read_name(read, strict=strict, remove_umi=remove_umi) is True
-    assert read.get_tag("RX") == "GATTACA"
+    assert read.get_tag("RX") == expected_umi
     if remove_umi:
         assert read.query_name == "abc:def:ghi:jfk:lmn:opq:rst"
     else:
-        assert read.query_name == "abc:def:ghi:jfk:lmn:opq:rst:GATTACA"
+        assert read.query_name == f"abc:def:ghi:jfk:lmn:opq:rst:{raw_umi}"
+
+
+def test_copy_invalid_multi_umi_strict_raises() -> None:
+    """Test that an invalid multi-UMI raises and does not set the RX tag when strict."""
+    builder = SamBuilder()
+    read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:AAAA+NNNZ")
+    with pytest.raises(ValueError, match="Invalid UMIs found in read name"):
+        copy_umi_from_read_name(read, strict=True)
+    assert read.has_tag("RX") is False
+
+
+def test_copy_invalid_multi_umi_non_strict_returns_false() -> None:
+    """Test that an invalid multi-UMI returns False and does not set the RX tag when not strict."""
+    builder = SamBuilder()
+    read = builder.add_single(name="abc:def:ghi:jfk:lmn:opq:rst:AAAA+NNNZ")
+    assert copy_umi_from_read_name(read, strict=False) is False
+    assert read.has_tag("RX") is False
 
 
 def test_populated_rx_tag_raises() -> None:

--- a/tests/fgpyo/platform/test_illumina.py
+++ b/tests/fgpyo/platform/test_illumina.py
@@ -149,6 +149,23 @@ def test_copy_invalid_multi_umi_non_strict_returns_false() -> None:
     assert read.has_tag("RX") is False
 
 
+def test_copy_umi_from_read_name_custom_read_name_delimiter() -> None:
+    """Test that a custom read_name_delimiter is used for both extraction and UMI removal."""
+    builder = SamBuilder()
+    read = builder.add_single(name="abc_def_ghi_AAAA+TTTT")
+    assert copy_umi_from_read_name(read, remove_umi=True, read_name_delimiter="_") is True
+    assert read.get_tag("RX") == "AAAA-TTTT"
+    assert read.query_name == "abc_def_ghi"
+
+
+def test_copy_umi_from_read_name_custom_umi_delimiter() -> None:
+    """Test that a custom umi_delimiter is forwarded when parsing multi-UMI segments."""
+    builder = SamBuilder()
+    read = builder.add_single(name="abc:def:ghi:AAAA|TTTT")
+    assert copy_umi_from_read_name(read, umi_delimiter="|") is True
+    assert read.get_tag("RX") == "AAAA-TTTT"
+
+
 def test_populated_rx_tag_raises() -> None:
     """Test that we raise a ValueError when a record already has a populated RX tag."""
     builder = SamBuilder()


### PR DESCRIPTION
## Summary

Fixes #289.

`copy_umi_from_read_name` was passing `:` (the read-name delimiter) as the UMI delimiter to `extract_umis_from_read_name`. By that point the raw UMI segment has already been split off, so splitting `"AAAA+TTTT"` by `:` yielded a single-element list, the whole `AAAA+TTTT` string was checked against the allowed UMI characters, and the `+` made it fail validation. Single-UMI read names happened to work because the inner split was a no-op, which is why this went unnoticed.

The fix drops the incorrect kwarg so the function's default (`_ILLUMINA_UMI_DELIMITER = "+"`) is used. `extract_umis_from_read_name` itself is unchanged.

Per review, the signature of `copy_umi_from_read_name` is also extended to expose `read_name_delimiter` and `umi_delimiter` (forwarded to `extract_umis_from_read_name`), so non-Illumina callers can use the higher-level helper without falling back to the underlying extractor. **Defaults match the existing Illumina constants, so all existing callers are unaffected.** The `remove_umi` branch now uses the passed-in `read_name_delimiter` rather than the hardcoded constant.

## Test plan

- [x] Multi-UMI happy path (`AAAA+TTTT` → `AAAA-TTTT`) now passes across all `(remove_umi, strict)` combinations.
- [x] Invalid multi-UMI (`AAAA+NNNZ`) raises in strict mode and returns `False` in non-strict mode, without setting `RX`.
- [x] Custom `read_name_delimiter` and `umi_delimiter` are exercised end-to-end, including the `remove_umi` path.
- [x] Incidentally fixes a pre-existing parametrize bug in `test_copy_valid_umi_from_read_name` that ran the same `(remove_umi, strict)` case twice.
- [ ] CI passes

Co-Authored-By: Claude <noreply@anthropic.com>