### PR TITLE
chore: migrate type annotations to PEP 604 syntax

### DIFF
--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -183,7 +183,6 @@ from typing import Dict
 from typing import Iterable
 from typing import Iterator
 from typing import List
-from typing import Optional
 from typing import Tuple
 from typing import cast
 
@@ -790,7 +789,7 @@ class PairOrientation(enum.Enum):
     @classmethod
     def from_recs(  # noqa: C901  # `from_recs` is too complex (11 > 10)
         cls, rec1: AlignedSegment, rec2: AlignedSegment | None = None
-    ) -> Optional["PairOrientation"]:
+    ) -> "PairOrientation | None":
         """
         Returns the pair orientation if both reads are mapped to the same reference sequence.
 
@@ -900,7 +899,7 @@ def is_proper_pair(
     rec2: AlignedSegment | None = None,
     max_insert_size: int = 1000,
     orientations: Collection[PairOrientation] = DefaultProperlyPairedOrientations,
-    isize: Callable[[AlignedSegment, Optional[AlignedSegment]], int] = isize,
+    isize: Callable[[AlignedSegment, AlignedSegment | None], int] = isize,
 ) -> bool:
     """
     Determines if a pair of records are properly paired or not.

--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -12,7 +12,6 @@ ex. https://pypi.org/project/Distance/
 from types import MappingProxyType
 from typing import Dict
 from typing import List
-from typing import Optional
 
 _COMPLEMENTS: Dict[str, str] = {
     # Discrete bases
@@ -61,7 +60,7 @@ _COMPLEMENTS: Dict[str, str] = {
 # Get str of all invalid nucleotide characters (strings missing from _COMPLEMENTS).
 _INVALID_BASES: str = "".join(c for c in (chr(o) for o in range(256)) if c not in _COMPLEMENTS)
 # Use str.maketrans to create a table matching ascii codes of bases to ascii codes of complements.
-_COMPLEMENTS_TABLE: MappingProxyType[int, Optional[int]] = MappingProxyType(
+_COMPLEMENTS_TABLE: MappingProxyType[int, int | None] = MappingProxyType(
     str.maketrans("".join(_COMPLEMENTS.keys()), "".join(_COMPLEMENTS.values()), _INVALID_BASES)
 )
 """

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -10,7 +10,6 @@ from types import UnionType
 from typing import Callable
 from typing import Iterable
 from typing import Literal
-from typing import Optional
 from typing import Type
 from typing import TypeGuard
 from typing import TypeVar
@@ -143,7 +142,7 @@ def _make_union_parser_worker(
     union: Type[UnionType],
     parsers: Iterable[Callable[[str], UnionType]],
     value: str,
-) -> Optional[UnionType]:
+) -> UnionType | None:
     """
     Worker function behind union parsing.
 
@@ -219,26 +218,26 @@ def none_parser(value: str) -> Literal[None]:
 
 
 @overload
-def all_not_none(values: tuple[Optional[T], ...]) -> TypeGuard[tuple[T, ...]]: ...
+def all_not_none(values: tuple[T | None, ...]) -> TypeGuard[tuple[T, ...]]: ...
 
 
 @overload
-def all_not_none(values: list[Optional[T]]) -> TypeGuard[list[T]]: ...
+def all_not_none(values: list[T | None]) -> TypeGuard[list[T]]: ...
 
 
 @overload
-def all_not_none(values: set[Optional[T]]) -> TypeGuard[set[T]]: ...
+def all_not_none(values: set[T | None]) -> TypeGuard[set[T]]: ...
 
 
 @overload
-def all_not_none(values: Sequence[Optional[T]]) -> TypeGuard[Sequence[T]]: ...
+def all_not_none(values: Sequence[T | None]) -> TypeGuard[Sequence[T]]: ...
 
 
 @overload
-def all_not_none(values: Collection[Optional[T]]) -> TypeGuard[Collection[T]]: ...
+def all_not_none(values: Collection[T | None]) -> TypeGuard[Collection[T]]: ...
 
 
-def all_not_none(values: Iterable[Optional[T]]) -> bool:
+def all_not_none(values: Iterable[T | None]) -> bool:
     """
     Type guard that checks all Optional collection elements are not None.
 

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -5,7 +5,6 @@ from tempfile import NamedTemporaryFile as NamedTemp
 from typing import Any
 from typing import Generator
 from typing import List
-from typing import Optional
 from typing import Tuple
 
 import pysam
@@ -958,7 +957,7 @@ def test_calc_edit_info_deletion_block_break_out_of_bounds() -> None:
 
 
 @pytest.mark.parametrize("query_sequence", [None, "*"])
-def test_calc_edit_info_with_missing_query_bases(query_sequence: Optional[str]) -> None:
+def test_calc_edit_info_with_missing_query_bases(query_sequence: str | None) -> None:
     """Assert expected behavior for a read that has missing query bases."""
     chrom = "AGTCCGTTA"
     builder = SamBuilder(r1_len=10)


### PR DESCRIPTION
## Summary

Fixes #286 (partial).

Now that fgpyo requires Python 3.10+ (#261), migrates annotation-site uses of `typing.Optional[T]` to PEP 604 `T | None` across `fgpyo/sam/__init__.py`, `fgpyo/sequence.py`, `fgpyo/util/types.py`, and `tests/fgpyo/sam/test_sam.py`. Unused `Optional` imports dropped.

`from typing import Union` is kept in `fgpyo/util/types.py` — still needed at runtime for the `origin is Union or origin is UnionType` check in `_is_optional`. Docstring references to the legacy syntaxes are preserved where they document accepted input forms.

## Deferred

Migrations in `tests/fgpyo/util/test_metric.py` and `tests/fgpyo/util/test_inspect.py` surfaced a latent bug in `_attribute_is_optional` and are split to #293 / #295.

Four parametrize cases in `tests/fgpyo/util/test_types.py` are intentionally kept as-is: they pair `Union[...]` with PEP 604 equivalents in `test_is_optional` to exercise both branches of the origin check, so migrating them would collapse the pairs and drop coverage of the legacy branch.

## Test plan

- [x] Lint, type-check, unit, and doctest suite passes.