### PR TITLE
fix: recognize PEP 604 union syntax and multi-arg unions as optional

### DIFF
--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -24,7 +24,6 @@ from typing import Type
 from typing import TypeAlias
 from typing import TypeGuard
 from typing import TypeVar
-from typing import Union
 
 import fgpyo.util.types as types
 
@@ -491,10 +490,7 @@ def attr_from(
 
 def _attribute_is_optional(attribute: FieldType) -> bool:
     """Returns True if the attribute is optional, False otherwise."""
-    origin = typing.get_origin(attribute.type)
-    return (origin is Union or origin is python_types.UnionType) and isinstance(
-        None, typing.get_args(attribute.type)
-    )
+    return types._is_optional(attribute.type)
 
 
 def _attribute_has_default(attribute: FieldType) -> bool:

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -491,7 +491,8 @@ def attr_from(
 
 def _attribute_is_optional(attribute: FieldType) -> bool:
     """Returns True if the attribute is optional, False otherwise."""
-    return typing.get_origin(attribute.type) is Union and isinstance(
+    origin = typing.get_origin(attribute.type)
+    return (origin is Union or origin is python_types.UnionType) and isinstance(
         None, typing.get_args(attribute.type)
     )
 

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -116,8 +116,7 @@ def _is_optional(dtype: TypeAnnotation) -> bool:
         dtype: A type.
 
     Returns:
-        True if the type is a union type with exactly two elements, one of which is `None`.
-        False otherwise.
+        True if the type is a union type that includes `None` in its arguments. False otherwise.
 
     Raises:
         TypeError: If the input is not a valid `TypeAnnotation` type.
@@ -130,12 +129,7 @@ def _is_optional(dtype: TypeAnnotation) -> bool:
 
     # Optional[T] has `typing.Union` as its origin, but PEP604 syntax (e.g. `int | None`) has
     # `types.UnionType` as its origin.
-    return (
-        origin is not None
-        and (origin is Union or origin is UnionType)
-        and len(args) == 2
-        and type(None) in args
-    )
+    return origin is not None and (origin is Union or origin is UnionType) and type(None) in args
 
 
 def _make_union_parser_worker(

--- a/tests/fgpyo/util/test_inspect.py
+++ b/tests/fgpyo/util/test_inspect.py
@@ -48,6 +48,15 @@ class LegacyOptionalName:
     union_with_none: Union[str, None] = None
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class MultiArgOptionalName:
+    """Test attr class with multi-arg union fields containing None."""
+
+    required: str
+    multi_arg_optional: str | int | None
+    legacy_multi_arg_optional: Union[str, int, None] = None
+
+
 def test_attr_from() -> None:
     name = attr_from(
         cls=Name,
@@ -94,6 +103,20 @@ def test_attribute_has_default_legacy_syntax() -> None:
     assert not _attribute_has_default(fields_dict["required"])
     assert _attribute_has_default(fields_dict["optional_no_default"])
     assert _attribute_has_default(fields_dict["union_with_none"])
+
+
+def test_attribute_is_optional_multi_arg_union() -> None:
+    fields_dict = attr.fields_dict(MultiArgOptionalName)
+    assert not _attribute_is_optional(fields_dict["required"])
+    assert _attribute_is_optional(fields_dict["multi_arg_optional"])
+    assert _attribute_is_optional(fields_dict["legacy_multi_arg_optional"])
+
+
+def test_attribute_has_default_multi_arg_union() -> None:
+    fields_dict = attr.fields_dict(MultiArgOptionalName)
+    assert not _attribute_has_default(fields_dict["required"])
+    assert _attribute_has_default(fields_dict["multi_arg_optional"])
+    assert _attribute_has_default(fields_dict["legacy_multi_arg_optional"])
 
 
 class Foo:

--- a/tests/fgpyo/util/test_inspect.py
+++ b/tests/fgpyo/util/test_inspect.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 import attr
 import pytest
@@ -28,9 +29,23 @@ class Name:
     required: str
     custom_parser: str
     converted: int = attr.field(converter=int)
+    optional_no_default: str | None
+    optional_with_default_none: str | None = None
+    optional_with_default_some: str | None = "foo"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class LegacyOptionalName:
+    """
+    Test attr class using legacy `Optional[T]` / `Union[T, None]` syntax.
+
+    Kept to ensure `_attribute_is_optional` continues to recognize the
+    `typing.Union` origin alongside `types.UnionType` (PEP 604).
+    """
+
+    required: str
     optional_no_default: Optional[str]
-    optional_with_default_none: Optional[str] = None
-    optional_with_default_some: Optional[str] = "foo"
+    union_with_none: Union[str, None] = None
 
 
 def test_attr_from() -> None:
@@ -57,6 +72,13 @@ def test_attribute_is_optional() -> None:
     assert _attribute_is_optional(fields_dict["optional_with_default_some"])
 
 
+def test_attribute_is_optional_legacy_syntax() -> None:
+    fields_dict = attr.fields_dict(LegacyOptionalName)
+    assert not _attribute_is_optional(fields_dict["required"])
+    assert _attribute_is_optional(fields_dict["optional_no_default"])
+    assert _attribute_is_optional(fields_dict["union_with_none"])
+
+
 def test_attribute_has_default() -> None:
     fields_dict = attr.fields_dict(Name)
     assert not _attribute_has_default(fields_dict["required"])
@@ -65,6 +87,13 @@ def test_attribute_has_default() -> None:
     assert _attribute_has_default(fields_dict["optional_no_default"])
     assert _attribute_has_default(fields_dict["optional_with_default_none"])
     assert _attribute_has_default(fields_dict["optional_with_default_some"])
+
+
+def test_attribute_has_default_legacy_syntax() -> None:
+    fields_dict = attr.fields_dict(LegacyOptionalName)
+    assert not _attribute_has_default(fields_dict["required"])
+    assert _attribute_has_default(fields_dict["optional_no_default"])
+    assert _attribute_has_default(fields_dict["union_with_none"])
 
 
 class Foo:

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -12,7 +12,6 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Type
@@ -108,8 +107,8 @@ class DataBuilder:
 
         @make_dataclass(use_attr=use_attr)
         class Person(Metric["Person"]):
-            name: Optional[str]
-            age: Optional[int]
+            name: str | None
+            age: int | None
 
         @make_dataclass(use_attr=use_attr)
         class Name:
@@ -145,7 +144,7 @@ class DataBuilder:
         @make_dataclass(use_attr=use_attr)
         class PersonMaybeAge(Metric["PersonMaybeAge"]):
             name: str
-            age: Optional[int]
+            age: int | None
 
         @make_dataclass(use_attr=use_attr)
         class PersonDefault(Metric["PersonDefault"]):
@@ -154,13 +153,13 @@ class DataBuilder:
 
         @make_dataclass(use_attr=use_attr)
         class PersonAgeFloat(Metric["PersonAgeFloat"]):
-            name: Optional[str]
-            age: Optional[float]
+            name: str | None
+            age: float | None
 
         @make_dataclass(use_attr=use_attr)
         class ListPerson(Metric["ListPerson"]):
-            name: List[Optional[str]]
-            age: List[Optional[int]]
+            name: List[str | None]
+            age: List[int | None]
 
         self.DummyMetric = DummyMetric
         self.Person = Person

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -948,3 +948,20 @@ def test_metric_str_or_none(use_attr: bool, tmp_path: Path) -> None:
     assert len(out_metrics) == 2
     assert out_metrics[0] == in_metrics[0]
     assert out_metrics[1] == in_metrics[1]
+
+
+@pytest.mark.parametrize("use_attr", [False, True])
+def test_metric_multi_arg_optional_missing_column(use_attr: bool, tmp_path: Path) -> None:
+    """A multi-arg optional column may be missing from the file (treated as None)."""
+
+    @make_dataclass(use_attr=use_attr)
+    class PersonMaybeId(Metric["PersonMaybeId"]):
+        name: str
+        identifier: str | int | None = None
+
+    path: Path = tmp_path / "metrics.txt"
+    with path.open("w") as writer:
+        writer.write("name\nMax\n")
+
+    out_metrics: List[PersonMaybeId] = list(PersonMaybeId.read(path=path))
+    assert out_metrics == [PersonMaybeId(name="Max", identifier=None)]

--- a/tests/fgpyo/util/test_types.py
+++ b/tests/fgpyo/util/test_types.py
@@ -26,9 +26,9 @@ def test_is_listlike() -> None:
         (Optional[str], True),
         (str | None, True),
         (Union[str, int], False),
-        (Union[str, int, None], False),
+        (Union[str, int, None], True),
         (str | int, False),
-        (str | int | None, False),
+        (str | int | None, True),
         (str, False),
     ],
 )


### PR DESCRIPTION
## Summary

Fixes #293. Fixes #296. Completes #286.

`fgpyo/util/inspect.py::_attribute_is_optional` only checked `typing.get_origin(attr.type) is Union`, so `Metric` and `attr_from` classes defined with PEP 604 annotations (`T | None`) treated optional fields as required — `Metric.read` raised `ValueError: fields in file missing from class` and `attr_from` failed the "No value given and no default" assertion. After consolidating the check to delegate to `types._is_optional` (which already handled PEP 604), a second gap surfaced: `_is_optional` required exactly 2 args, so multi-arg unions like `str | int | None` were not recognized as optional either. Both gaps are fixed.

Also picks up the PEP 604 migrations in `tests/fgpyo/util/test_metric.py` (7 sites) and `tests/fgpyo/util/test_inspect.py` (3 sites) that were deferred from #292 because they exercise these code paths.

## Test plan

- [x] `_attribute_is_optional` / `_attribute_has_default` recognize both `Optional[T]` / `Union[T, None]` (legacy) and `T | None` (PEP 604) fields — covered by new `LegacyOptionalName`-based tests.
- [x] `_attribute_is_optional` / `_attribute_has_default` recognize multi-arg optional fields (`str | int | None`, `Union[str, int, None]`) — covered by new `MultiArgOptionalName`-based tests.
- [x] `Metric` round-trip test confirms a multi-arg optional column may be missing from the file and is read as `None`.
- [x] Existing `test_is_optional` parametrize updated: `Union[str, int, None]` and `str | int | None` now expected to be optional.
- [x] Lint, type-check, unit (831), and doctest (17) suite passes.