### PR TITLE
feat: add mode kwarg to fgpyo.vcf.writer

### DIFF
--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -96,7 +96,11 @@ def reader(path: VcfPath) -> Generator[VcfReader, None, None]:
 
 
 @contextmanager
-def writer(path: VcfPath, header: VariantHeader) -> Generator[VcfWriter, None, None]:
+def writer(
+    path: VcfPath,
+    header: VariantHeader,
+    mode: str = "w",
+) -> Generator[VcfWriter, None, None]:
     """
     Opens the given path for VCF writing.
 
@@ -104,6 +108,10 @@ def writer(path: VcfPath, header: VariantHeader) -> Generator[VcfWriter, None, N
         path: the path to a VCF, or an open filehandle
         header: the source for the output VCF header. If you are modifying a VCF file that you are
                 reading from, you can pass reader.header
+        mode: the pysam write mode. The default `"w"` relies on pysam auto-detecting the output
+                format from the filename extension (e.g. `.vcf.gz` → bgzipped). Callers passing an
+                open file handle should supply an explicit mode — `"wz"` for bgzipped VCF, `"wb"`
+                for BCF — since there is no filename to sniff.
     """
     if not isinstance(path, (str, Path, io.IOBase)):
         raise TypeError(f"Cannot open '{type(path)}' for VCF writing.")
@@ -111,7 +119,8 @@ def writer(path: VcfPath, header: VariantHeader) -> Generator[VcfWriter, None, N
     # with a .vcf.gz suffix.
     if isinstance(path, Path):
         path = str(path)
-    _writer = VariantFile(path, header=header, mode="w")
+    # pysam's stubs narrow `mode` and `path` below what's accepted at runtime (e.g. mode="wz").
+    _writer = VariantFile(path, header=header, mode=mode)  # type: ignore[arg-type]
     try:
         yield _writer
     finally:

--- a/tests/fgpyo/vcf/test_io.py
+++ b/tests/fgpyo/vcf/test_io.py
@@ -48,3 +48,28 @@ def test_writer_rejects_non_path_non_handle() -> None:
     with pytest.raises(TypeError, match="Cannot open"):
         with vcf_writer(123, header=header):  # type: ignore[arg-type]
             pass
+
+
+_BGZF_MAGIC = b"\x1f\x8b"
+
+
+def test_writer_file_handle_bgzipped_round_trip(tmp_path: Path) -> None:
+    builder = VariantBuilder()
+    record = builder.add()
+    out = tmp_path / "out.vcf.gz"
+    with open(out, "wb") as handle:
+        with vcf_writer(handle, header=builder.header, mode="wz") as w:
+            w.write(record)
+    assert out.read_bytes()[:2] == _BGZF_MAGIC
+    with vcf_reader(out) as r:
+        records = list(r)
+    assert len(records) == 1
+
+
+def test_writer_default_mode_autodetects_bgzip(tmp_path: Path) -> None:
+    builder = VariantBuilder()
+    record = builder.add()
+    out = tmp_path / "out.vcf.gz"
+    with vcf_writer(out, header=builder.header) as w:
+        w.write(record)
+    assert out.read_bytes()[:2] == _BGZF_MAGIC

--- a/tests/fgpyo/vcf/test_io.py
+++ b/tests/fgpyo/vcf/test_io.py
@@ -50,7 +50,7 @@ def test_writer_rejects_non_path_non_handle() -> None:
             pass
 
 
-_BGZF_MAGIC = b"\x1f\x8b"
+_BGZF_MAGIC: bytes = b"\x1f\x8b"
 
 
 def test_writer_file_handle_bgzipped_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #297

`fgpyo.vcf.writer` passed `mode="w"` to `pysam.VariantFile` unconditionally. For `str` / `Path` inputs pysam auto-detects format from the filename extension, but for `io.IOBase` inputs (reachable since #290) there is no filename to sniff, so output is always uncompressed VCF regardless of how the handle was opened.

Forward an explicit `mode` kwarg to `VariantFile`, defaulting to `"w"`. File-handle callers can now request bgzipped VCF with `mode="wz"` or BCF with `mode="wb"`.

**Existing `str` / `Path` callers are unaffected** — the default preserves the filename-based auto-detection they rely on, and a new regression test locks that in.

Typed as `str` rather than a `Literal[...]` because pysam's own stub omits `"wz"` even though it works at runtime; narrowing would reject valid modes. Suppressed on the `VariantFile` call the same way the reader side already does.

## Test plan

- New tests verify: writing via `open(path, "wb") + mode="wz"` produces a bgzipped file (gzip magic bytes) that round-trips through `reader()`; `writer(path.vcf.gz)` with default mode still produces bgzipped output.
- Existing `tests/fgpyo/vcf/` suite, mypy, and ruff all clean.