### PR TITLE
chore: migrate type annotations to PEP 585 built-in generics

### DIFF
--- a/fgpyo/_requirements.py
+++ b/fgpyo/_requirements.py
@@ -1,6 +1,6 @@
 """Enforce requirements."""
 
-from typing import Callable
+from collections.abc import Callable
 
 
 class RequirementError(Exception):

--- a/fgpyo/collections/__init__.py
+++ b/fgpyo/collections/__init__.py
@@ -78,14 +78,13 @@ StopIteration
 iterable objects as well as iterators.
 """
 
+from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Iterator
 from itertools import pairwise
 from operator import le
 from typing import Any
-from typing import Callable
 from typing import Generic
-from typing import Iterable
-from typing import Iterator
-from typing import List
 from typing import Protocol
 from typing import TypeVar
 
@@ -144,7 +143,7 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
         else:
             raise StopIteration
 
-    def takewhile(self, pred: Callable[[IterType], bool]) -> List[IterType]:
+    def takewhile(self, pred: Callable[[IterType], bool]) -> list[IterType]:
         """
         Consumes from the iterator while pred is true, and returns the result as a List.
 
@@ -159,7 +158,7 @@ class PeekableIterator(Generic[IterType], Iterator[IterType]):
             List[V]: A list of the values from the iterator, in order, up until and excluding
             the first value that does not match the predicate.
         """
-        xs: List[IterType] = []
+        xs: list[IterType] = []
         while self.can_peek() and pred(self._peek):
             xs.append(next(self))
         return xs

--- a/fgpyo/fasta/builder.py
+++ b/fgpyo/fasta/builder.py
@@ -47,12 +47,11 @@ Add bases to existing contig:
 """
 
 import textwrap
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import Iterator
 
 from pysam import FastaFile
 
@@ -179,7 +178,7 @@ class FastaBuilder:
         self.assembly: str = assembly
         self.species: str = species
         self.line_length: int = line_length
-        self.__contig_builders: Dict[str, ContigBuilder] = {}
+        self.__contig_builders: dict[str, ContigBuilder] = {}
 
     def __getitem__(self, key: str) -> ContigBuilder:
         """Access instance of ContigBuilder by name."""

--- a/fgpyo/fasta/sequence_dictionary.py
+++ b/fgpyo/fasta/sequence_dictionary.py
@@ -129,18 +129,16 @@ import copy
 import itertools
 import re
 import sys
+from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import replace
 from enum import unique
 from pathlib import Path
+from re import Pattern
 from typing import Any
-from typing import Dict
-from typing import Iterator
-from typing import List
-from typing import Mapping
-from typing import MutableMapping
-from typing import Pattern
 from typing import overload
 
 from fgpyo import sam
@@ -177,7 +175,7 @@ class Keys(StrEnum):
     URI = "UR"
 
     @staticmethod
-    def attributes() -> List[str]:
+    def attributes() -> list[str]:
         """
         The list of keys that are allowed to be attributes in `SequenceMetadata`.
 
@@ -253,7 +251,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
     name: str
     length: int
     index: int
-    attributes: Dict[Keys | str, str] = field(default_factory=dict)
+    attributes: dict[Keys | str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Any post initialization validation should go here."""
@@ -267,13 +265,13 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
             raise ValueError(f"'{Keys.SEQUENCE_LENGTH}' should not given in the list of attributes")
 
     @property
-    def aliases(self) -> List[str]:
+    def aliases(self) -> list[str]:
         """The aliases (not including the primary) name."""
         aliases = self.attributes.get(Keys.ALIASES)
         return [] if aliases is None else aliases.split(",")
 
     @property
-    def all_names(self) -> List[str]:
+    def all_names(self) -> list[str]:
         """A list of all names, including the primary name and aliases, in that order."""
         return [self.name] + self.aliases
 
@@ -344,14 +342,14 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
         else:
             return self_m5 == other_m5
 
-    def to_sam(self) -> Dict[str, Any]:
+    def to_sam(self) -> dict[str, Any]:
         """
         Converts the sequence metadata to a SAM-formatted dictionary.
 
         Equivalent to one item in the list of sequences from
         `pysam.AlignmentHeader#to_dict()["SQ"]`.
         """
-        meta_dict: Dict[str, Any] = {
+        meta_dict: dict[str, Any] = {
             f"{Keys.SEQUENCE_NAME}": self.name,
             f"{Keys.SEQUENCE_LENGTH}": self.length,
         }
@@ -361,7 +359,7 @@ class SequenceMetadata(MutableMapping[Keys | str, str]):
         return meta_dict
 
     @staticmethod
-    def from_sam(meta: Dict[Keys | str, Any], index: int) -> "SequenceMetadata":
+    def from_sam(meta: dict[Keys | str, Any], index: int) -> "SequenceMetadata":
         """
         Builds a `SequenceMetadata` from a dictionary.
 
@@ -436,13 +434,13 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
         infos: the ordered collection of sequence metadata
     """
 
-    infos: List[SequenceMetadata]
-    _dict: Dict[str, SequenceMetadata] = field(init=False, repr=False)
+    infos: list[SequenceMetadata]
+    _dict: dict[str, SequenceMetadata] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Builds the internal name-to-metadata lookup dictionary."""
         # Initialize a mapping from sequence name to the sequence metadata for all names
-        self_dict: Dict[str, SequenceMetadata] = {}
+        self_dict: dict[str, SequenceMetadata] = {}
         for index, info in enumerate(self.infos):
             if info.index != index:
                 raise ValueError(
@@ -466,13 +464,13 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
             return False
         return all(this.same_as(that) for this, that in zip(self.infos, other.infos, strict=True))
 
-    def to_sam(self) -> List[Dict[str, Any]]:
+    def to_sam(self) -> list[dict[str, Any]]:
         """Converts the list of dictionaries, one per sequence."""
         return [meta.to_sam() for meta in self.infos]
 
     def to_sam_header(
         self,
-        extra_header: Dict[str, Any] | None = None,
+        extra_header: dict[str, Any] | None = None,
     ) -> pysam.AlignmentHeader:
         """
         Converts the sequence dictionary to a `pysam.AlignmentHeader`.
@@ -481,7 +479,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
             extra_header: a dictionary of extra values to add to the header, None otherwise.  See
                           `:~pysam.AlignmentHeader` for more details.
         """
-        header_dict: Dict[str, Any] = {
+        header_dict: dict[str, Any] = {
             "HD": {"VN": "1.5"},
             "SQ": self.to_sam(),
         }
@@ -503,11 +501,11 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
 
     @staticmethod
     @overload
-    def from_sam(data: List[Dict[str, Any]]) -> "SequenceDictionary": ...
+    def from_sam(data: list[dict[str, Any]]) -> "SequenceDictionary": ...
 
     @staticmethod
     def from_sam(
-        data: Path | pysam.AlignmentFile | pysam.AlignmentHeader | List[Dict[str, Any]],
+        data: Path | pysam.AlignmentFile | pysam.AlignmentHeader | list[dict[str, Any]],
     ) -> "SequenceDictionary":
         """
         Creates a `SequenceDictionary` from a SAM file or its header.
@@ -531,7 +529,7 @@ class SequenceDictionary(Mapping[str | int, SequenceMetadata]):
                 seq_dict = SequenceDictionary.from_sam(fh.header)
         else:  # assuming `data` is a `list[dict[str, Any]]`
             try:
-                infos: List[SequenceMetadata] = [
+                infos: list[SequenceMetadata] = [
                     SequenceMetadata.from_sam(meta=meta, index=index)
                     for index, meta in enumerate(data)
                 ]

--- a/fgpyo/fastx/__init__.py
+++ b/fgpyo/fastx/__init__.py
@@ -26,13 +26,10 @@ seq2: GGGG, seq2: TTTT
 
 """
 
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from pathlib import Path
 from types import TracebackType
-from typing import Iterator
-from typing import List
-from typing import Tuple
-from typing import Type
 
 from pysam import FastxFile
 from pysam import FastxRecord
@@ -40,7 +37,7 @@ from pysam import FastxRecord
 from fgpyo.util.types import all_not_none
 
 
-class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
+class FastxZipped(AbstractContextManager, Iterator[tuple[FastxRecord, ...]]):
     """
     A context manager that will lazily zip over any number of FASTA/FASTQ files.
 
@@ -55,7 +52,7 @@ class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
         if len(paths) <= 0:
             raise ValueError(f"Must provide at least one FASTX to {self.__class__.__name__}")
         self._persist: bool = persist
-        self._paths: Tuple[Path | str, ...] = paths
+        self._paths: tuple[Path | str, ...] = paths
         self._fastx = tuple(FastxFile(str(path), persist=self._persist) for path in self._paths)
 
     @staticmethod
@@ -63,14 +60,14 @@ class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
         """Return the name of the FASTX record minus its ordinal suffix (e.g. "/1" or "/2")."""
         return name[: len(name) - 2] if len(name) >= 2 and name[-2] == "/" else name
 
-    def __next__(self) -> Tuple[FastxRecord, ...]:
+    def __next__(self) -> tuple[FastxRecord, ...]:
         """Return the next set of FASTX records from the zipped FASTX files."""
         records = tuple(next(handle, None) for handle in self._fastx)
 
         if all(record is None for record in records):
             raise StopIteration
         elif not all_not_none(records):
-            non_none_names: List[str | None] = [
+            non_none_names: list[str | None] = [
                 record.name for record in records if record is not None
             ]
             assert all_not_none(non_none_names)  # type narrowing
@@ -86,9 +83,9 @@ class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
                 )
             )
 
-        names_with_ordinals: List[str | None] = [record.name for record in records]
+        names_with_ordinals: list[str | None] = [record.name for record in records]
         assert all_not_none(names_with_ordinals)  # type narrowing
-        record_names: List[str] = [self._name_minus_ordinal(name) for name in names_with_ordinals]
+        record_names: list[str] = [self._name_minus_ordinal(name) for name in names_with_ordinals]
         if len(set(record_names)) != 1:
             raise ValueError(f"FASTX record names do not all match, found: {record_names}")
 
@@ -96,7 +93,7 @@ class FastxZipped(AbstractContextManager, Iterator[Tuple[FastxRecord, ...]]):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:

--- a/fgpyo/io/__init__.py
+++ b/fgpyo/io/__init__.py
@@ -63,21 +63,20 @@ Read lines from a path into a generator:
 import os
 import sys
 import warnings
+from collections.abc import Generator
+from collections.abc import Iterable
+from collections.abc import Iterator
 from contextlib import contextmanager
 from io import TextIOWrapper
 from pathlib import Path
 from typing import IO
 from typing import Any
-from typing import Generator
-from typing import Iterable
-from typing import Iterator
-from typing import Set
 from typing import cast
 
 from zlib_ng import gzip_ng
 from zlib_ng import gzip_ng_threaded
 
-COMPRESSED_FILE_EXTENSIONS: Set[str] = {".gz", ".bgz"}
+COMPRESSED_FILE_EXTENSIONS: set[str] = {".gz", ".bgz"}
 
 
 def assert_path_is_readable(path: Path) -> None:

--- a/fgpyo/platform/illumina.py
+++ b/fgpyo/platform/illumina.py
@@ -9,15 +9,13 @@ The functions in this module make it easy to:
 
 """
 
-from typing import Set
-
 from pysam import AlignedSegment
 
 SAM_UMI_DELIMITER: str = "-"
 """Multiple UMI delimiter, which SAM specification recommends should be a hyphen;
 see specification here: https://samtools.github.io/hts-specs/SAMtags.pdf"""
 
-_VALID_UMI_CHARACTERS: Set[str] = set("ACGTN")
+_VALID_UMI_CHARACTERS: set[str] = set("ACGTN")
 """Illumina's restricted UMI characters;
 https://support.illumina.com/help/BaseSpace_Sequence_Hub_OLH_009008_2/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm."""  # noqa
 

--- a/fgpyo/read_structure.py
+++ b/fgpyo/read_structure.py
@@ -49,10 +49,8 @@ Read structure missing length information: 23T2T[T]23T
 """
 
 import enum
-from typing import Iterable
-from typing import Iterator
-from typing import List
-from typing import Tuple
+from collections.abc import Iterable
+from collections.abc import Iterator
 
 import attr
 
@@ -219,7 +217,7 @@ class ReadStructure(Iterable[ReadSegment]):
 
     """
 
-    segments: Tuple[ReadSegment, ...]
+    segments: tuple[ReadSegment, ...]
 
     @property
     def _min_length(self) -> int:
@@ -257,35 +255,35 @@ class ReadStructure(Iterable[ReadSegment]):
             last_segment = attr.evolve(last_segment, length=None)
             return ReadStructure(segments=self.segments[:-1] + (last_segment,))
 
-    def extract(self, bases: str) -> Tuple[SubReadWithoutQuals, ...]:
+    def extract(self, bases: str) -> tuple[SubReadWithoutQuals, ...]:
         """Splits the given bases into tuples with its associated read segment."""
         return tuple([segment.extract(bases=bases) for segment in self])
 
-    def extract_with_quals(self, bases: str, quals: str) -> Tuple[SubReadWithQuals, ...]:
+    def extract_with_quals(self, bases: str, quals: str) -> tuple[SubReadWithQuals, ...]:
         """Splits the given bases and qualities into triples with its associated read segment."""
         return tuple([segment.extract_with_quals(bases=bases, quals=quals) for segment in self])
 
-    def segments_by_kind(self, kind: SegmentType) -> Tuple[ReadSegment, ...]:
+    def segments_by_kind(self, kind: SegmentType) -> tuple[ReadSegment, ...]:
         """Returns just the segments of a given kind."""
         return tuple([segment for segment in self if segment.kind == kind])
 
-    def template_segments(self) -> Tuple[ReadSegment, ...]:
+    def template_segments(self) -> tuple[ReadSegment, ...]:
         """Returns segments of kind Template."""
         return self.segments_by_kind(kind=SegmentType.Template)
 
-    def sample_barcode_segments(self) -> Tuple[ReadSegment, ...]:
+    def sample_barcode_segments(self) -> tuple[ReadSegment, ...]:
         """Returns segments of kind SampleBarcode."""
         return self.segments_by_kind(kind=SegmentType.SampleBarcode)
 
-    def molecular_barcode_segments(self) -> Tuple[ReadSegment, ...]:
+    def molecular_barcode_segments(self) -> tuple[ReadSegment, ...]:
         """Returns segments of kind MolecularBarcode."""
         return self.segments_by_kind(kind=SegmentType.MolecularBarcode)
 
-    def cell_barcode_segments(self) -> Tuple[ReadSegment, ...]:
+    def cell_barcode_segments(self) -> tuple[ReadSegment, ...]:
         """Returns segments of kind CellBarcode."""
         return self.segments_by_kind(kind=SegmentType.CellBarcode)
 
-    def skip_segments(self) -> Tuple[ReadSegment, ...]:
+    def skip_segments(self) -> tuple[ReadSegment, ...]:
         """Returns segments of kind Skip."""
         return self.segments_by_kind(kind=SegmentType.Skip)
 
@@ -307,7 +305,7 @@ class ReadStructure(Iterable[ReadSegment]):
 
     @classmethod
     def from_segments(
-        cls, segments: Tuple[ReadSegment, ...], reset_offsets: bool = False
+        cls, segments: tuple[ReadSegment, ...], reset_offsets: bool = False
     ) -> "ReadStructure":
         """Creates a new ReadStructure, optionally resetting the offsets on each of the segments."""
         # Check that none but the last segment has an indefinite length
@@ -340,9 +338,9 @@ class ReadStructure(Iterable[ReadSegment]):
         return cls.from_segments(segments=cls._from_string(string=tidied), reset_offsets=True)
 
     @classmethod
-    def _from_string(cls, string: str) -> Tuple[ReadSegment, ...]:
+    def _from_string(cls, string: str) -> tuple[ReadSegment, ...]:
         index = 0
-        segments: List[ReadSegment] = []
+        segments: list[ReadSegment] = []
         while index < len(string):
             # tash the beginning position of our parsing so we can highlight what we're having
             # trouble with

--- a/fgpyo/sam/__init__.py
+++ b/fgpyo/sam/__init__.py
@@ -173,17 +173,14 @@ import enum
 import io
 import sys
 from array import array
+from collections.abc import Callable
 from collections.abc import Collection
+from collections.abc import Iterable
+from collections.abc import Iterator
 from itertools import chain
 from pathlib import Path
 from typing import IO
 from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import Iterable
-from typing import Iterator
-from typing import List
-from typing import Tuple
 from typing import cast
 
 import attr
@@ -235,10 +232,10 @@ _OK_BASES: set[str] = {"A", "C", "G", "T", "="}
 _IOClasses = (io.TextIOBase, io.BufferedIOBase, io.RawIOBase, io.IOBase)
 """The classes that should be treated as file-like classes"""
 
-_STDIN_PATHS: List[str] = ["-", "stdin", "/dev/stdin"]
+_STDIN_PATHS: list[str] = ["-", "stdin", "/dev/stdin"]
 """Paths that should be opened as standard input."""
 
-_STDOUT_PATHS: List[str] = ["-", "stdout", "/dev/stdout"]
+_STDOUT_PATHS: list[str] = ["-", "stdout", "/dev/stdout"]
 """Paths that should be opened as standard output."""
 
 
@@ -374,7 +371,7 @@ def reader(path: SamPath, file_type: SamFileType | None = None, unmapped: bool =
 
 def writer(
     path: SamPath,
-    header: str | Dict[str, Any] | SamHeader,
+    header: str | dict[str, Any] | SamHeader,
     file_type: SamFileType | None = None,
 ) -> SamFile:
     """
@@ -411,7 +408,7 @@ class _CigarOpUtil:
     This is to speed up the translation of cigar op code to CigarOp in CigarOp, so needs to be
     declared beforehand.
     """
-    CODE_TO_CHARACTER: Dict[int, str] = {
+    CODE_TO_CHARACTER: dict[int, str] = {
         0: "M",
         1: "I",
         2: "D",
@@ -531,10 +528,10 @@ class Cigar:
         - elements (Tuple[CigarElement, ...]): zero or more cigar elements
     """
 
-    elements: Tuple[CigarElement, ...] = ()
+    elements: tuple[CigarElement, ...] = ()
 
     @classmethod
-    def from_cigartuples(cls, cigartuples: List[Tuple[int, int]] | None) -> "Cigar":
+    def from_cigartuples(cls, cigartuples: list[tuple[int, int]] | None) -> "Cigar":
         """
         Returns a Cigar from a list of tuples returned by pysam.
 
@@ -639,7 +636,7 @@ class Cigar:
         """
         if len(self.elements) <= 1:
             return self
-        result: List[CigarElement] = []
+        result: list[CigarElement] = []
         for elem in self.elements:
             if result and result[-1].operator == elem.operator:
                 result[-1] = CigarElement(
@@ -653,7 +650,7 @@ class Cigar:
             return self
         return Cigar(coalesced)
 
-    def query_alignment_offsets(self) -> Tuple[int, int]:
+    def query_alignment_offsets(self) -> tuple[int, int]:
         """
         Gets the 0-based, end-exclusive positions of the first and last aligned base in the query.
 
@@ -713,7 +710,7 @@ class Cigar:
         if length < 0:
             raise ValueError(f"length must be >= 0, got {length}")
         remaining = length
-        builder: List[CigarElement] = []
+        builder: list[CigarElement] = []
         for elem in self.elements:
             if remaining <= 0:
                 break
@@ -994,7 +991,7 @@ class SupplementaryAlignment:
         )
 
     @staticmethod
-    def parse_sa_tag(tag: str) -> List["SupplementaryAlignment"]:
+    def parse_sa_tag(tag: str) -> list["SupplementaryAlignment"]:
         """
         Parses an SA tag of supplementary alignments from a BAM file.
 
@@ -1005,7 +1002,7 @@ class SupplementaryAlignment:
         return [SupplementaryAlignment.parse(a) for a in tag.split(";") if len(a) > 0]
 
     @classmethod
-    def from_read(cls, read: pysam.AlignedSegment) -> List["SupplementaryAlignment"]:
+    def from_read(cls, read: pysam.AlignedSegment) -> list["SupplementaryAlignment"]:
         """
         Construct a list of SupplementaryAlignments from the SA tag in a pysam.AlignedSegment.
 
@@ -1368,10 +1365,10 @@ class Template:
     name: str
     r1: AlignedSegment | None
     r2: AlignedSegment | None
-    r1_supplementals: List[AlignedSegment]
-    r2_supplementals: List[AlignedSegment]
-    r1_secondaries: List[AlignedSegment]
-    r2_secondaries: List[AlignedSegment]
+    r1_supplementals: list[AlignedSegment]
+    r2_supplementals: list[AlignedSegment]
+    r1_secondaries: list[AlignedSegment]
+    r2_secondaries: list[AlignedSegment]
 
     @staticmethod
     def iterator(alns: Iterator[AlignedSegment]) -> Iterator["Template"]:
@@ -1388,10 +1385,10 @@ class Template:
         name = None
         r1 = None
         r2 = None
-        r1_supplementals: List[AlignedSegment] = []
-        r2_supplementals: List[AlignedSegment] = []
-        r1_secondaries: List[AlignedSegment] = []
-        r2_secondaries: List[AlignedSegment] = []
+        r1_supplementals: list[AlignedSegment] = []
+        r2_supplementals: list[AlignedSegment] = []
+        r1_secondaries: list[AlignedSegment] = []
+        r2_secondaries: list[AlignedSegment] = []
 
         for rec in recs:
             if name is None:

--- a/fgpyo/sam/builder.py
+++ b/fgpyo/sam/builder.py
@@ -6,15 +6,12 @@ alignment records, for use in testing.
 """
 
 from array import array
+from collections.abc import Callable
 from pathlib import Path
 from random import Random
 from tempfile import NamedTemporaryFile
 from typing import IO
 from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Tuple
 from typing import cast
 
 import pysam
@@ -56,7 +53,7 @@ class SamBuilder:
     DEFAULT_R2_LENGTH: int = 100
 
     @staticmethod
-    def default_sd() -> List[Dict[str, Any]]:
+    def default_sd() -> list[dict[str, Any]]:
         """
         Generates the sequence dictionary that is used by default by SamBuilder.
 
@@ -94,7 +91,7 @@ class SamBuilder:
         ]
 
     @staticmethod
-    def default_rg() -> Dict[str, str]:
+    def default_rg() -> dict[str, str]:
         """Returns the default read group used by the SamBuilder, as a dictionary."""
         return {"ID": "1", "SM": "1_AAAAAA", "LB": "default", "PL": "ILLUMINA", "PU": "xxx.1"}
 
@@ -104,9 +101,9 @@ class SamBuilder:
         r2_len: int | None = None,
         base_quality: int = 30,
         mapping_quality: int = 60,
-        sd: List[Dict[str, Any]] | None = None,
-        rg: Dict[str, str] | None = None,
-        extra_header: Dict[str, Any] | None = None,
+        sd: list[dict[str, Any]] | None = None,
+        rg: dict[str, str] | None = None,
+        extra_header: dict[str, Any] | None = None,
         seed: int = 42,
         sort_order: SamOrder = SamOrder.Coordinate,
     ) -> None:
@@ -134,7 +131,7 @@ class SamBuilder:
             raise ValueError(f"sort_order must be a SamOrder, got {type(sort_order)}")
         self._sort_order = sort_order
 
-        self._header: Dict[str, Any] = {
+        self._header: dict[str, Any] = {
             "HD": {"VN": "1.5", "SO": sort_order.value},
             "SQ": (sd if sd is not None else SamBuilder.default_sd()),
             "RG": [(rg if rg is not None else SamBuilder.default_rg())],
@@ -145,7 +142,7 @@ class SamBuilder:
         self._seq_lookup = dict([(s["SN"], s) for s in self._header["SQ"]])
 
         self._random: Random = Random(seed)
-        self._records: List[AlignedSegment] = []
+        self._records: list[AlignedSegment] = []
         self._counter: int = 0
 
     def _next_name(self) -> str:
@@ -164,7 +161,7 @@ class SamBuilder:
         chrom: str,
         start: int,
         mapq: int | None,
-        attrs: Dict[str, Any] | None,
+        attrs: dict[str, Any] | None,
     ) -> AlignedSegment:
         """
         Generates a new AlignedSegment.
@@ -235,7 +232,7 @@ class SamBuilder:
         rec: pysam.AlignedSegment,
         length: int,
         bases: str | None = _UNSET,
-        quals: List[int] | None = _UNSET,
+        quals: list[int] | None = _UNSET,
         cigar: str | None = None,
     ) -> None:
         """
@@ -285,7 +282,7 @@ class SamBuilder:
 
     def _resolve_quals(
         self,
-        quals: List[int] | None,
+        quals: list[int] | None,
         bases: str | None,
         length: int,
     ) -> "array[int] | None":
@@ -302,11 +299,11 @@ class SamBuilder:
             return None
         return array("B", [self.base_quality] * length)
 
-    def rg(self) -> Dict[str, Any]:
+    def rg(self) -> dict[str, Any]:
         """Returns the single read group that is defined in the header."""
         # The `RG` field contains a list of read group mappings
         # e.g. `[{"ID": "rg1", "PL": "ILLUMINA"}]`
-        rgs = cast(List[Dict[str, Any]], self._header["RG"])
+        rgs = cast(list[dict[str, Any]], self._header["RG"])
         assert len(rgs) == 1, "Header did not contain exactly one read group!"
         return rgs[0]
 
@@ -322,8 +319,8 @@ class SamBuilder:
         name: str | None = None,
         bases1: str | None = _UNSET,
         bases2: str | None = _UNSET,
-        quals1: List[int] | None = _UNSET,
-        quals2: List[int] | None = _UNSET,
+        quals1: list[int] | None = _UNSET,
+        quals2: list[int] | None = _UNSET,
         chrom: str | None = None,
         chrom1: str | None = None,
         chrom2: str | None = None,
@@ -335,8 +332,8 @@ class SamBuilder:
         mapq2: int | None = None,
         strand1: str = "+",
         strand2: str = "-",
-        attrs: Dict[str, Any] | None = None,
-    ) -> Tuple[AlignedSegment, AlignedSegment]:
+        attrs: dict[str, Any] | None = None,
+    ) -> tuple[AlignedSegment, AlignedSegment]:
         """
         Generates a new pair of reads, adds them to the internal collection, and returns them.
 
@@ -465,7 +462,7 @@ class SamBuilder:
         name: str | None = None,
         read_num: int | None = None,
         bases: str | None = _UNSET,
-        quals: List[int] | None = _UNSET,
+        quals: list[int] | None = _UNSET,
         chrom: str = sam.NO_REF_NAME,
         start: int = sam.NO_REF_POS,
         cigar: str | None = None,
@@ -473,7 +470,7 @@ class SamBuilder:
         strand: str = "+",
         secondary: bool = False,
         supplementary: bool = False,
-        attrs: Dict[str, Any] | None = None,
+        attrs: dict[str, Any] | None = None,
     ) -> AlignedSegment:
         """
         Generates a new single reads, adds them to the internal collection, and returns it.
@@ -616,11 +613,11 @@ class SamBuilder:
         """Returns the number of records accumulated so far."""
         return len(self._records)
 
-    def to_unsorted_list(self) -> List[pysam.AlignedSegment]:
+    def to_unsorted_list(self) -> list[pysam.AlignedSegment]:
         """Returns the accumulated records in the order they were created."""
         return list(self._records)
 
-    def to_sorted_list(self) -> List[pysam.AlignedSegment]:
+    def to_sorted_list(self) -> list[pysam.AlignedSegment]:
         """Returns the accumulated records in coordinate order."""
         with NamedTemporaryFile(suffix=".bam", delete=True) as fp:
             filename = fp.name

--- a/fgpyo/sam/clipping.py
+++ b/fgpyo/sam/clipping.py
@@ -58,10 +58,8 @@ cat clipped.bam | samtools sort -n | samtools fixmate | samtools sort | samtools
 """  # noqa: E501
 
 from array import array
-from typing import Iterable
-from typing import List
+from collections.abc import Iterable
 from typing import NamedTuple
-from typing import Tuple
 
 from pysam import AlignedSegment
 
@@ -358,7 +356,7 @@ def _read_pos_at_ref_pos(
 
 def _clip(
     cigar: Cigar, quals: array, bases_to_clip: int, clipped_base_quality: int | None
-) -> Tuple[Cigar, ClippingInfo]:
+) -> tuple[Cigar, ClippingInfo]:
     """
     Workhorse private clipping method that clips the start of cigars.
 
@@ -378,7 +376,7 @@ def _clip(
     existing_soft_clips = elems.takewhile(lambda c: c.operator == CigarOp.S)
     read_bases_clipped = 0
     ref_bases_clipped = 0
-    new_elems: List[CigarElement] = []  # buffer of cigar elements used to make the returned cigar
+    new_elems: list[CigarElement] = []  # buffer of cigar elements used to make the returned cigar
 
     # Returns true if the operator immediately after the clipping point is a deletion
     def is_trailing_deletion() -> bool:

--- a/fgpyo/sequence.py
+++ b/fgpyo/sequence.py
@@ -10,10 +10,8 @@ ex. https://pypi.org/project/Distance/
 """
 
 from types import MappingProxyType
-from typing import Dict
-from typing import List
 
-_COMPLEMENTS: Dict[str, str] = {
+_COMPLEMENTS: dict[str, str] = {
     # Discrete bases
     "A": "T",
     "C": "G",
@@ -146,7 +144,7 @@ def levenshtein(string1: str, string2: str) -> int:
     # B - - - 2
     # C - - - 1
     # " 3 2 1 0
-    matrix: List[List[int]] = [[int()] * (m + 1) for _ in range(n + 1)]
+    matrix: list[list[int]] = [[int()] * (m + 1) for _ in range(n + 1)]
     for j in range(m + 1):
         matrix[n][j] = m - j
     for i in range(n + 1):

--- a/fgpyo/util/inspect.py
+++ b/fgpyo/util/inspect.py
@@ -2,6 +2,9 @@ import dataclasses
 import functools
 import types as python_types
 import typing
+from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Mapping
 from dataclasses import MISSING as DATACLASSES_MISSING
 from dataclasses import fields as get_dataclasses_fields
 from dataclasses import is_dataclass as is_dataclasses_class
@@ -10,17 +13,9 @@ from functools import partial
 from pathlib import PurePath
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import ClassVar
-from typing import Dict
-from typing import FrozenSet
-from typing import Iterable
-from typing import List
 from typing import Literal
-from typing import Mapping
 from typing import Protocol
-from typing import Tuple
-from typing import Type
 from typing import TypeAlias
 from typing import TypeGuard
 from typing import TypeVar
@@ -28,7 +23,7 @@ from typing import TypeVar
 import fgpyo.util.types as types
 
 attr: python_types.ModuleType | None
-MISSING: FrozenSet[Any]
+MISSING: frozenset[Any]
 
 
 # Always define get_attr_fields and get_attr_fields_dict at the module level for documentation tools
@@ -53,11 +48,11 @@ except ImportError:  # pragma: no cover
     # called because the import failed; but they're here to ensure that the function is defined in
     # sections of code that don't know if the import was successful or not.
 
-    def get_attr_fields(_cls: type) -> Tuple[dataclasses.Field, ...]:
+    def get_attr_fields(_cls: type) -> tuple[dataclasses.Field, ...]:
         """Get tuple of fields for attr class. attrs isn't imported so return empty tuple."""
         return ()
 
-    def get_attr_fields_dict(_cls: type) -> Dict[str, dataclasses.Field]:
+    def get_attr_fields_dict(_cls: type) -> dict[str, dataclasses.Field]:
         """Get dict of name->field for attr class. attrs isn't imported so return empty dict."""
         return {}
 
@@ -71,7 +66,7 @@ else:
     class DataclassInstance(Protocol):
         """Protocol for dataclass instances when _typeshed is unavailable."""
 
-        __dataclasses_fields__: ClassVar[Dict[str, dataclasses.Field[Any]]]
+        __dataclasses_fields__: ClassVar[dict[str, dataclasses.Field[Any]]]
 
 
 if TYPE_CHECKING and _use_attr:  # pragma: no cover
@@ -89,7 +84,7 @@ def is_attr_class(cls: type) -> TypeGuard[type[AttrsInstance]]:
     return hasattr(cls, "__attrs_attrs__")
 
 
-_MISSING_OR_NONE: FrozenSet[Any] = frozenset({*MISSING, None})
+_MISSING_OR_NONE: frozenset[Any] = frozenset({*MISSING, None})
 """Set of values that are considered missing or None for dataclasses or attr classes"""
 _DataclassesOrAttrClass: TypeAlias = DataclassInstance | AttrsInstance
 """
@@ -104,8 +99,8 @@ corresponding _DataclassesOrAttrClass
 
 
 def _get_dataclasses_fields_dict(
-    class_or_instance: DataclassInstance | Type[DataclassInstance],
-) -> Dict[str, dataclasses.Field]:
+    class_or_instance: DataclassInstance | type[DataclassInstance],
+) -> dict[str, dataclasses.Field]:
     """Get a dict from field name to Field for a dataclass class or instance."""
     return {field.name: field for field in get_dataclasses_fields(class_or_instance)}
 
@@ -119,7 +114,7 @@ def split_at_given_level(
     split_delim: str = ",",
     increase_depth_chars: Iterable[str] = ("{", "(", "["),
     decrease_depth_chars: Iterable[str] = ("}", ")", "]"),
-) -> List[str]:
+) -> list[str]:
     """
     Splits a nested field by its outer-most level.
 
@@ -130,7 +125,7 @@ def split_at_given_level(
     """
     outer_depth_of_split = 0
     current_outer_splits = []
-    out_vals: List[str] = []
+    out_vals: list[str] = []
     for high_level_split in field.split(split_delim):
         increase_in_depth = 0
         for char in increase_depth_chars:
@@ -155,7 +150,7 @@ NoneType: TypeAlias = type(None)  # type: ignore[no-redef]
 
 
 def list_parser(
-    cls: Type, type_: TypeAlias, parsers: Dict[type, Callable[[str], Any]] | None = None
+    cls: type, type_: TypeAlias, parsers: dict[type, Callable[[str], Any]] | None = None
 ) -> partial:
     """
     Returns a function that parses a "stringified" list into a `List` of the correct type.
@@ -184,7 +179,7 @@ def list_parser(
 
 
 def set_parser(
-    cls: Type, type_: TypeAlias, parsers: Dict[type, Callable[[str], Any]] | None = None
+    cls: type, type_: TypeAlias, parsers: dict[type, Callable[[str], Any]] | None = None
 ) -> partial:
     """
     Returns a function that parses a stringified set into a `Set` of the correct type.
@@ -215,7 +210,7 @@ def set_parser(
 
 
 def tuple_parser(
-    cls: Type, type_: TypeAlias, parsers: Dict[type, Callable[[str], Any]] | None = None
+    cls: type, type_: TypeAlias, parsers: dict[type, Callable[[str], Any]] | None = None
 ) -> partial:
     """
     Returns a function that parses a stringified tuple into a `Tuple` of the correct type.
@@ -236,7 +231,7 @@ def tuple_parser(
         for subtype in typing.get_args(type_)
     ]
 
-    def tuple_parse(tuple_string: str) -> Tuple[Any, ...]:
+    def tuple_parse(tuple_string: str) -> tuple[Any, ...]:
         """
         Parses a dictionary value (can do so recursively).
 
@@ -259,7 +254,7 @@ def tuple_parser(
 
 
 def dict_parser(
-    cls: Type, type_: TypeAlias, parsers: Dict[type, Callable[[str], Any]] | None = None
+    cls: type, type_: TypeAlias, parsers: dict[type, Callable[[str], Any]] | None = None
 ) -> partial:
     """
     Returns a function that parses a stringified dict into a `Dict` of the correct type.
@@ -286,7 +281,7 @@ def dict_parser(
         ),
     )
 
-    def dict_parse(dict_string: str) -> Dict[Any, Any]:
+    def dict_parse(dict_string: str) -> dict[Any, Any]:
         """Parses a dictionary value (can do so recursively)."""
         assert dict_string[0] == "{", "Dict val improperly formatted"
         assert dict_string[-1] == "}", "Dict val improprly formatted"
@@ -312,7 +307,7 @@ def dict_parser(
 
 
 def _get_parser(  # noqa: C901
-    cls: Type, type_: TypeAlias, parsers: Dict[type, Callable[[str], Any]] | None = None
+    cls: type[Any], type_: TypeAlias, parsers: dict[type, Callable[[str], Any]] | None = None
 ) -> partial:
     """
     Attempts to find a parser for a provided type.
@@ -392,7 +387,7 @@ def _get_parser(  # noqa: C901
 
 
 def get_fields_dict(
-    cls: _DataclassesOrAttrClass | Type[_DataclassesOrAttrClass],
+    cls: _DataclassesOrAttrClass | type[_DataclassesOrAttrClass],
 ) -> Mapping[str, FieldType]:
     """Get the fields dict from either a dataclasses or attr dataclass (or instance)."""
     if is_dataclasses_class(cls):
@@ -407,8 +402,8 @@ def get_fields_dict(
 
 
 def get_fields(
-    cls: _DataclassesOrAttrClass | Type[_DataclassesOrAttrClass],
-) -> Tuple[FieldType, ...]:
+    cls: _DataclassesOrAttrClass | type[_DataclassesOrAttrClass],
+) -> tuple[FieldType, ...]:
     """Get the fields tuple from either a dataclasses or attr dataclass (or instance)."""
     if is_dataclasses_class(cls):
         return get_dataclasses_fields(cls)
@@ -425,9 +420,9 @@ _AttrFromType = TypeVar("_AttrFromType")
 
 
 def attr_from(
-    cls: Type[_AttrFromType],
-    kwargs: Dict[str, str],
-    parsers: Dict[type, Callable[[str], Any]] | None = None,
+    cls: type[_AttrFromType],
+    kwargs: dict[str, str],
+    parsers: dict[type, Callable[[str], Any]] | None = None,
 ) -> _AttrFromType:
     """
     Builds an attr or dataclasses class from key-word arguments.
@@ -438,7 +433,7 @@ def attr_from(
         parsers: a dictionary of parser functions to apply to specific types
 
     """
-    return_values: Dict[str, Any] = {}
+    return_values: dict[str, Any] = {}
     for attribute in get_fields(cls):  # type: ignore[arg-type]
         return_value: Any
         if attribute.name in kwargs:

--- a/fgpyo/util/logging.py
+++ b/fgpyo/util/logging.py
@@ -34,12 +34,12 @@ True
 
 import logging
 import socket
+from collections.abc import Callable
+from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from logging import Logger
 from threading import RLock
 from typing import Any
-from typing import Callable
-from typing import Iterable
 from typing import Literal
 
 from pysam import AlignedSegment

--- a/fgpyo/util/metric.py
+++ b/fgpyo/util/metric.py
@@ -125,6 +125,9 @@ PersonWithName(name=Name(first='john', last='doe'), age=42)
 
 import dataclasses
 from abc import ABC
+from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from csv import DictWriter
 from dataclasses import dataclass
@@ -134,14 +137,7 @@ from io import TextIOWrapper
 from pathlib import Path
 from types import TracebackType
 from typing import Any
-from typing import Callable
-from typing import Dict
 from typing import Generic
-from typing import Iterable
-from typing import Iterator
-from typing import List
-from typing import Tuple
-from typing import Type
 from typing import TypeGuard
 from typing import TypeVar
 
@@ -164,8 +160,8 @@ class MetricFileHeader:
         fieldnames: The field names specified in the final line of the header.
     """
 
-    preamble: List[str]
-    fieldnames: List[str]
+    preamble: list[str]
+    fieldnames: list[str]
 
 
 class Metric(ABC, Generic[MetricType]):
@@ -191,21 +187,21 @@ class Metric(ABC, Generic[MetricType]):
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
             yield getattr(self, field.name)
 
-    def items(self) -> Iterator[Tuple[str, Any]]:
+    def items(self) -> Iterator[tuple[str, Any]]:
         """An iterator over field names and values in the same order as the header."""
         for field in inspect.get_fields(self.__class__):  # type: ignore[arg-type]
             yield (field.name, getattr(self, field.name))
 
-    def formatted_values(self) -> List[str]:
+    def formatted_values(self) -> list[str]:
         """An iterator over formatted attribute values in the same order as the header."""
         return [self.format_value(value) for value in self.values()]
 
-    def formatted_items(self) -> List[Tuple[str, str]]:
+    def formatted_items(self) -> list[tuple[str, str]]:
         """An iterator over formatted attribute values in the same order as the header."""
         return [(key, self.format_value(value)) for key, value in self.items()]
 
     @classmethod
-    def _parsers(cls) -> Dict[type, Callable[[str], Any]]:
+    def _parsers(cls) -> dict[type, Callable[[str], Any]]:
         """
         Mapping of type to a specific parser for that type.
 
@@ -239,7 +235,7 @@ class Metric(ABC, Generic[MetricType]):
         """
         parsers = cls._parsers()
         with io.to_reader(path, threads=threads) as reader:
-            header: List[str] = reader.readline().rstrip("\r\n").split("\t")
+            header: list[str] = reader.readline().rstrip("\r\n").split("\t")
             # check the header
             class_fields = set(cls.header())
             file_fields = set(header)
@@ -277,7 +273,7 @@ class Metric(ABC, Generic[MetricType]):
             # read the metric lines
             for lineno, line in enumerate(reader, 2):
                 # parse the raw values
-                values: List[str] = line.rstrip("\r\n").split("\t")
+                values: list[str] = line.rstrip("\r\n").split("\t")
                 if strip_whitespace:
                     values = [v.strip() for v in values]
 
@@ -295,7 +291,7 @@ class Metric(ABC, Generic[MetricType]):
                 yield instance
 
     @classmethod
-    def parse(cls, fields: List[str]) -> Any:
+    def parse(cls, fields: list[str]) -> Any:
         """
         Parses the string-representation of this metric.
 
@@ -325,7 +321,7 @@ class Metric(ABC, Generic[MetricType]):
             writer.writeall(values)
 
     @classmethod
-    def header(cls) -> List[str]:
+    def header(cls) -> list[str]:
         """The list of header values for the metric."""
         return [a.name for a in inspect.get_fields(cls)]  # type: ignore[arg-type]
 
@@ -383,7 +379,7 @@ class Metric(ABC, Generic[MetricType]):
             return f"{value}"
 
     @classmethod
-    def to_list(cls, value: str) -> List[Any]:
+    def to_list(cls, value: str) -> list[Any]:
         """Returns a list value split on comma delimeter."""
         return [] if value == "" else value.split(",")
 
@@ -427,8 +423,8 @@ class Metric(ABC, Generic[MetricType]):
         Raises:
             ValueError: If the file was empty or contained only comments or empty lines.
         """
-        preamble: List[str] = []
-        fieldnames: List[str] = []
+        preamble: list[str] = []
+        fieldnames: list[str] = []
 
         for line in reader:
             if line.strip().startswith(comment_prefix) or line.strip() == "":
@@ -459,19 +455,19 @@ def _is_metric_class(cls: Any) -> TypeGuard[Metric]:
 class MetricWriter(Generic[MetricType], AbstractContextManager):
     """Writes Metric instances to a delimited file."""
 
-    _metric_class: Type[Metric]
-    _fieldnames: List[str]
+    _metric_class: type[Metric]
+    _fieldnames: list[str]
     _fout: TextIOWrapper
     _writer: DictWriter
 
     def __init__(
         self,
         filename: Path | str,
-        metric_class: Type[Metric],
+        metric_class: type[Metric],
         append: bool = False,
         delimiter: str = "\t",
-        include_fields: List[str] | None = None,
-        exclude_fields: List[str] | None = None,
+        include_fields: list[str] | None = None,
+        exclude_fields: list[str] | None = None,
         lineterminator: str = "\n",
         threads: int | None = None,
     ) -> None:
@@ -510,7 +506,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
         if (filepath.is_fifo() or filepath.is_char_device()) and append:
             raise ValueError("Cannot append to stdout, stderr, or other named pipe or stream")
 
-        ordered_fieldnames: List[str] = _validate_and_generate_final_output_fieldnames(
+        ordered_fieldnames: list[str] = _validate_and_generate_final_output_fieldnames(
             metric_class=metric_class,
             include_fields=include_fields,
             exclude_fields=exclude_fields,
@@ -547,7 +543,7 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
@@ -600,10 +596,10 @@ class MetricWriter(Generic[MetricType], AbstractContextManager):
 
 
 def _validate_and_generate_final_output_fieldnames(
-    metric_class: Type[MetricType],
-    include_fields: List[str] | None = None,
-    exclude_fields: List[str] | None = None,
-) -> List[str]:
+    metric_class: type[MetricType],
+    include_fields: list[str] | None = None,
+    exclude_fields: list[str] | None = None,
+) -> list[str]:
     """
     Subset and/or re-order the Metric's fieldnames based on the specified include/exclude lists.
 
@@ -636,9 +632,9 @@ def _validate_and_generate_final_output_fieldnames(
 
 def _assert_file_header_matches_metric(
     path: Path,
-    metric_class: Type[MetricType],
+    metric_class: type[MetricType],
     delimiter: str,
-    ordered_fieldnames: List[str] | None = None,
+    ordered_fieldnames: list[str] | None = None,
 ) -> None:
     """
     Check that the specified file has a header and its fields match those of the provided Metric.
@@ -662,7 +658,7 @@ def _assert_file_header_matches_metric(
     if header.fieldnames == []:
         raise ValueError(f"Could not find a header in the provided file: {path}")
 
-    fieldnames: List[str] = (
+    fieldnames: list[str] = (
         ordered_fieldnames if ordered_fieldnames is not None else list(metric_class.keys())
     )
 
@@ -677,8 +673,8 @@ def _assert_file_header_matches_metric(
 
 
 def _assert_fieldnames_are_metric_attributes(
-    specified_fieldnames: List[str],
-    metric_class: Type[MetricType],
+    specified_fieldnames: list[str],
+    metric_class: type[MetricType],
 ) -> None:
     """
     Check that all of the specified fields are attributes on the given Metric.
@@ -698,7 +694,7 @@ def _assert_fieldnames_are_metric_attributes(
         )
 
 
-def _assert_is_metric_class(cls: Type[Metric]) -> None:
+def _assert_is_metric_class(cls: type[Metric]) -> None:
     """
     Assert that the given class is a Metric.
 

--- a/fgpyo/util/string.py
+++ b/fgpyo/util/string.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def column_it(rows: List[List[str]], delimiter: str = " ") -> str:
+def column_it(rows: list[list[str]], delimiter: str = " ") -> str:
     """
     A simple version of Unix's `column` utility.  This assumes the table is NxM.
 
@@ -12,7 +9,7 @@ def column_it(rows: List[List[str]], delimiter: str = " ") -> str:
     # get the # of columns
     num_columns = len(rows[0])
     # for each column, find the maximum length of a cell
-    max_column_lengths: List[int] = [
+    max_column_lengths: list[int] = [
         max(len(row[col_i]) for row in rows) for col_i in range(num_columns)
     ]
     # pad each row in the table

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -2,22 +2,20 @@ import collections
 import inspect
 import types
 import typing
+from collections.abc import Callable
 from collections.abc import Collection
+from collections.abc import Iterable
 from collections.abc import Sequence
 from enum import Enum
 from functools import partial
 from types import UnionType
-from typing import Callable
-from typing import Iterable
 from typing import Literal
-from typing import Type
+from typing import TypeAlias
 from typing import TypeGuard
 from typing import TypeVar
 from typing import Union
 from typing import cast
 from typing import overload
-
-from typing_extensions import TypeAlias
 
 EnumType = TypeVar("EnumType", bound="Enum")
 # conceptually bound to "Literal" but that's not valid in the spec
@@ -45,7 +43,7 @@ def parse_bool(string: str) -> bool:
         raise ValueError("{} is not a valid boolean string".format(string))
 
 
-def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
+def _make_enum_parser_worker(enum: type[EnumType], value: str) -> EnumType:
     """
     Worker function behind enum parsing.
 
@@ -61,7 +59,7 @@ def _make_enum_parser_worker(enum: Type[EnumType], value: str) -> EnumType:
         ) from ex
 
 
-def make_enum_parser(enum: Type[EnumType]) -> partial:
+def make_enum_parser(enum: type[EnumType]) -> partial:
     """Makes a parser function for enum classes."""
     return partial(_make_enum_parser_worker, enum)
 
@@ -133,7 +131,7 @@ def _is_optional(dtype: TypeAnnotation) -> bool:
 
 
 def _make_union_parser_worker(
-    union: Type[UnionType],
+    union: type[UnionType],
     parsers: Iterable[Callable[[str], UnionType]],
     value: str,
 ) -> UnionType | None:
@@ -162,14 +160,14 @@ def _make_union_parser_worker(
 
 
 def make_union_parser(
-    union: Type[UnionType], parsers: Iterable[Callable[[str], UnionType]]
+    union: type[UnionType], parsers: Iterable[Callable[[str], UnionType]]
 ) -> partial:
     """Generates a parser function for a union type object."""
     return partial(_make_union_parser_worker, union, parsers)
 
 
 def _make_literal_parser_worker(
-    literal: Type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]], value: str
+    literal: type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]], value: str
 ) -> LiteralType:
     """
     Worker function behind literal parsing.
@@ -193,7 +191,7 @@ def _make_literal_parser_worker(
 
 
 def make_literal_parser(
-    literal: Type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]]
+    literal: type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]]
 ) -> partial:
     """Generates a parser function for a literal type object."""
     return partial(_make_literal_parser_worker, literal, parsers)

--- a/fgpyo/util/types.py
+++ b/fgpyo/util/types.py
@@ -131,7 +131,7 @@ def _is_optional(dtype: TypeAnnotation) -> bool:
 
 
 def _make_union_parser_worker(
-    union: type[UnionType],
+    union: TypeAnnotation,
     parsers: Iterable[Callable[[str], UnionType]],
     value: str,
 ) -> UnionType | None:
@@ -160,14 +160,14 @@ def _make_union_parser_worker(
 
 
 def make_union_parser(
-    union: type[UnionType], parsers: Iterable[Callable[[str], UnionType]]
+    union: TypeAnnotation, parsers: Iterable[Callable[[str], UnionType]]
 ) -> partial:
     """Generates a parser function for a union type object."""
     return partial(_make_union_parser_worker, union, parsers)
 
 
 def _make_literal_parser_worker(
-    literal: type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]], value: str
+    literal: TypeAnnotation, parsers: Iterable[Callable[[str], LiteralType]], value: str
 ) -> LiteralType:
     """
     Worker function behind literal parsing.
@@ -191,7 +191,7 @@ def _make_literal_parser_worker(
 
 
 def make_literal_parser(
-    literal: type[LiteralType], parsers: Iterable[Callable[[str], LiteralType]]
+    literal: TypeAnnotation, parsers: Iterable[Callable[[str], LiteralType]]
 ) -> partial:
     """Generates a parser function for a literal type object."""
     return partial(_make_literal_parser_worker, literal, parsers)

--- a/fgpyo/vcf/__init__.py
+++ b/fgpyo/vcf/__init__.py
@@ -59,9 +59,9 @@ in coordinate sorted order via the
 """
 
 import io
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
 
 from pysam import VariantFile
 from pysam import VariantFile as VcfReader

--- a/fgpyo/vcf/builder.py
+++ b/fgpyo/vcf/builder.py
@@ -1,14 +1,11 @@
 """# Classes for generating VCF and records for testing."""
 
+from collections.abc import Iterable
+from collections.abc import Iterator
 from enum import Enum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import Iterator
-from typing import List
-from typing import Tuple
 
 import pysam
 from pysam import VariantHeader
@@ -37,7 +34,7 @@ class VcfFieldNumber(Enum):
     UNKNOWN = "."
 
 
-MissingRep = Tuple[None, ...] | None
+MissingRep = tuple[None, ...] | None
 
 
 class VariantBuilder:
@@ -73,16 +70,16 @@ class VariantBuilder:
         header: the pysam header
     """
 
-    sample_ids: List[str]
-    sd: Dict[str, Dict[str, Any]]
-    seq_idx_lookup: Dict[str, int]
-    records: List[VariantRecord]
+    sample_ids: list[str]
+    sd: dict[str, dict[str, Any]]
+    seq_idx_lookup: dict[str, int]
+    records: list[VariantRecord]
     header: VariantHeader
 
     def __init__(
         self,
         sample_ids: Iterable[str] | None = None,
-        sd: Dict[str, Dict[str, Any]] | None = None,
+        sd: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         """
         Initializes a new VariantBuilder for generating variants and VCF files.
@@ -91,10 +88,10 @@ class VariantBuilder:
             sample_ids: the name of the sample(s)
             sd: optional sequence dictionary
         """
-        self.sample_ids: List[str] = list(sample_ids) if sample_ids is not None else []
-        self.sd: Dict[str, Dict[str, Any]] = sd if sd is not None else VariantBuilder.default_sd()
-        self.seq_idx_lookup: Dict[str, int] = {name: i for i, name in enumerate(self.sd.keys())}
-        self.records: List[VariantRecord] = []
+        self.sample_ids: list[str] = list(sample_ids) if sample_ids is not None else []
+        self.sd: dict[str, dict[str, Any]] = sd if sd is not None else VariantBuilder.default_sd()
+        self.seq_idx_lookup: dict[str, int] = {name: i for i, name in enumerate(self.sd.keys())}
+        self.records: list[VariantRecord] = []
         self.header = VariantHeader()
         for line in VariantBuilder._build_header_string(sd=self.sd):
             self.header.add_line(line)
@@ -102,7 +99,7 @@ class VariantBuilder:
             self.header.add_samples(sample_ids)
 
     @classmethod
-    def default_sd(cls) -> Dict[str, Dict[str, Any]]:
+    def default_sd(cls) -> dict[str, dict[str, Any]]:
         """
         Generates the default sequence dictionary for VariantBuilder.
 
@@ -112,14 +109,14 @@ class VariantBuilder:
             A new copy of the sequence dictionary as a map of contig name to dictionary, one per
             contig.
         """
-        sd: Dict[str, Dict[str, Any]] = {}
+        sd: dict[str, dict[str, Any]] = {}
         for sequence in SamBuilder.default_sd():
             contig = sequence["SN"]
             sd[contig] = {"ID": contig, "length": sequence["LN"]}
         return sd
 
     @classmethod
-    def _build_header_string(cls, sd: Dict[str, Dict[str, Any]] | None = None) -> Iterator[str]:
+    def _build_header_string(cls, sd: dict[str, dict[str, Any]] | None = None) -> Iterator[str]:
         """
         Builds the VCF header with the given sample name(s) and sequence dictionary.
 
@@ -179,8 +176,8 @@ class VariantBuilder:
         alts: str | Iterable[str] | None = (".",),
         qual: int = 60,
         filter: str | Iterable[str] | None = None,  # noqa: A002
-        info: Dict[str, Any] | None = None,
-        samples: Dict[str, Dict[str, Any]] | None = None,
+        info: dict[str, Any] | None = None,
+        samples: dict[str, dict[str, Any]] | None = None,
     ) -> VariantRecord:
         """
         Generates a new variant and adds it to the internal collection.
@@ -342,15 +339,15 @@ class VariantBuilder:
             assert path.is_file()
         return path
 
-    def to_unsorted_list(self) -> List[VariantRecord]:
+    def to_unsorted_list(self) -> list[VariantRecord]:
         """Returns the accumulated records in the order they were created."""
         return list(self.records)
 
-    def to_sorted_list(self) -> List[VariantRecord]:
+    def to_sorted_list(self) -> list[VariantRecord]:
         """Returns the accumulated records in coordinate order."""
         return sorted(self.records, key=self._sort_key)
 
-    def _sort_key(self, variant: VariantRecord) -> Tuple[int, int, int]:
+    def _sort_key(self, variant: VariantRecord) -> tuple[int, int, int]:
         return self.seq_idx_lookup[variant.contig], variant.start, variant.stop
 
     def add_header_line(self, line: str) -> None:

--- a/tests/fgpyo/collections/test_is_sorted.py
+++ b/tests/fgpyo/collections/test_is_sorted.py
@@ -1,6 +1,5 @@
 from functools import total_ordering
 from typing import Any
-from typing import List
 
 import pytest
 
@@ -79,7 +78,7 @@ def test_is_sorted_raises_on_non_comparable_objects() -> None:
             self.field = field
 
     # NB: an exception is only raised when there are more than one objects
-    iterable: List[MyClass] = [MyClass(field=1), MyClass(field=2)]
+    iterable: list[MyClass] = [MyClass(field=1), MyClass(field=2)]
 
     with pytest.raises(TypeError):
         # NB: the type ignore below checks that MyPy is aware the custom class is incorrectly typed
@@ -107,8 +106,8 @@ def test_is_sorted_on_custom_comparable_objects() -> None:
             return NotImplemented
 
     # NB: comparisons only occur when there are more than one object in the iterable.
-    iterable_sorted: List[MyClass] = [MyClass(field=1), MyClass(field=2)]
-    iterable_unsorted: List[MyClass] = [MyClass(field=2), MyClass(field=1)]
+    iterable_sorted: list[MyClass] = [MyClass(field=1), MyClass(field=2)]
+    iterable_unsorted: list[MyClass] = [MyClass(field=2), MyClass(field=1)]
 
     assert is_sorted(iterable_sorted)
     assert not is_sorted(iterable_unsorted)

--- a/tests/fgpyo/fasta/test_sequence_dictionary.py
+++ b/tests/fgpyo/fasta/test_sequence_dictionary.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 from typing import Any
-from typing import Dict
-from typing import List
 
 import pysam
 import pytest
@@ -198,7 +196,7 @@ def test_sequence_metadata_to_and_from_sam() -> None:
     attributes[Keys.ALTERNATE_LOCUS] = "chr2:3-4"
     meta = SequenceMetadata(name="1", length=1, index=0, attributes=attributes)
 
-    sam_dict: Dict[Keys | str, Any] = {
+    sam_dict: dict[Keys | str, Any] = {
         Keys.SEQUENCE_NAME: meta.name,
         Keys.SEQUENCE_LENGTH: meta.length,
         Keys.ALIASES: ",".join(meta.aliases),
@@ -272,7 +270,7 @@ def test_sequence_dictionary_mutable_mapping() -> None:
         ],
     ],
 )
-def test_sequence_dictionary_index_out_of_order(infos: List[SequenceMetadata]) -> None:
+def test_sequence_dictionary_index_out_of_order(infos: list[SequenceMetadata]) -> None:
     with pytest.raises(ValueError, match="Infos must be given with index set correctly."):
         SequenceDictionary(infos=infos)
 
@@ -294,7 +292,7 @@ def test_sequence_dictionary_index_out_of_order(infos: List[SequenceMetadata]) -
         ],
     ],
 )
-def test_sequence_dictionary_duplicate_names(infos: List[SequenceMetadata]) -> None:
+def test_sequence_dictionary_duplicate_names(infos: list[SequenceMetadata]) -> None:
     with pytest.raises(ValueError, match="Found duplicate sequence name"):
         SequenceDictionary(infos=infos)
 
@@ -324,7 +322,7 @@ def test_sequence_dictionary_to_and_from_sam() -> None:
             SequenceMetadata(name="chr2", length=20, index=1, attributes={Keys.ALIASES: "chr3"}),
         ]
     )
-    mapping: List[Dict[str, Any]] = [
+    mapping: list[dict[str, Any]] = [
         {Keys.SEQUENCE_NAME: "chr1", Keys.SEQUENCE_LENGTH: 10},
         {Keys.SEQUENCE_NAME: "chr2", Keys.SEQUENCE_LENGTH: 20, Keys.ALIASES: "chr3"},
     ]

--- a/tests/fgpyo/io/test_io.py
+++ b/tests/fgpyo/io/test_io.py
@@ -6,7 +6,6 @@ import stat
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
-from typing import List
 
 import pytest
 
@@ -132,7 +131,7 @@ def test_writer(suffix: str, expected: Any, threads: int | None) -> None:
 )
 def test_read_and_write_lines(
     suffix: str,
-    list_to_write: List[Any],
+    list_to_write: list[Any],
     threads: int | None,
 ) -> None:
     """Test fgpyo.fio.read_lines and write_lines."""

--- a/tests/fgpyo/sam/test_builder.py
+++ b/tests/fgpyo/sam/test_builder.py
@@ -1,7 +1,6 @@
 """Basic tests of the builder module."""
 
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -408,7 +407,7 @@ def make_sort_order_builder(tmp_path: Path, sort_order: SamOrder) -> Path:
     ],
     ids=["Coordinate sorting", "Query name sorting", "Unsorted output", "Unknown sorting"],
 )
-def test_sort_types(tmp_path: Path, sort_order: SamOrder, expected_name_order: List[str]) -> None:
+def test_sort_types(tmp_path: Path, sort_order: SamOrder, expected_name_order: list[str]) -> None:
     bam_path = make_sort_order_builder(tmp_path=tmp_path, sort_order=sort_order)
     with sam.reader(bam_path) as in_bam:
         for name in expected_name_order:

--- a/tests/fgpyo/sam/test_cigar.py
+++ b/tests/fgpyo/sam/test_cigar.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import pytest
 
 from fgpyo.sam import Cigar
@@ -23,7 +21,7 @@ cigar = Cigar.from_cigarstring("1M4D45N37X23I11=")
         ("76I", (0, 76)),
     ],
 )
-def test_query_alignment_offsets(cigar_string: str, expected_range: Tuple[int, int]) -> None:
+def test_query_alignment_offsets(cigar_string: str, expected_range: tuple[int, int]) -> None:
     """cig.query_alignment_offsets() should return the expected results."""
     cig = Cigar.from_cigarstring(cigar_string)
     ret = cig.query_alignment_offsets()
@@ -68,7 +66,7 @@ def test_query_alignment_offsets_failures(cigar_string: str) -> None:
     ],
 )
 def test_query_alignment_offsets_reversed(
-    cigar_string: str, expected_range: Tuple[int, int]
+    cigar_string: str, expected_range: tuple[int, int]
 ) -> None:
     """cig.revered().query_alignment_offsets() should return the expected results."""
     cig = Cigar.from_cigarstring(cigar_string)

--- a/tests/fgpyo/sam/test_sam.py
+++ b/tests/fgpyo/sam/test_sam.py
@@ -1,11 +1,9 @@
 """Tests for :py:mod:`~fgpyo.sam`."""
 
+from collections.abc import Generator
 from pathlib import Path
 from tempfile import NamedTemporaryFile as NamedTemp
 from typing import Any
-from typing import Generator
-from typing import List
-from typing import Tuple
 
 import pysam
 import pytest
@@ -126,7 +124,7 @@ def test_unmapped_sam_open_reading_exception(unmapped_sam: Path) -> None:
 
 
 @pytest.fixture
-def expected_records(valid_sam: Path) -> List[pysam.AlignedSegment]:
+def expected_records(valid_sam: Path) -> list[pysam.AlignedSegment]:
     """Returns the records that are found in the valid_sam."""
     with sam.reader(valid_sam) as fh:
         return [r for r in fh]
@@ -140,7 +138,7 @@ def header_dict(valid_sam: Path) -> AlignmentHeader:
 
 
 def assert_actual_vs_expected(
-    actual_path: str, expected_records: List[pysam.AlignedSegment]
+    actual_path: str, expected_records: list[pysam.AlignedSegment]
 ) -> None:
     """Helper method to ensure the expected records are in the SAM/BAM at the actual path."""
     with sam.reader(actual_path) as sam_reader:
@@ -153,7 +151,7 @@ def assert_actual_vs_expected(
 @pytest.mark.parametrize("file_type", [SamFileType.SAM, SamFileType.BAM])
 def test_sam_file_open_writing(
     file_type: SamFileType,
-    expected_records: List[pysam.AlignedSegment],
+    expected_records: list[pysam.AlignedSegment],
     header_dict: AlignmentHeader,
     tmp_path: Path,
 ) -> None:
@@ -172,7 +170,7 @@ def test_sam_file_open_writing(
 
 
 def test_sam_file_open_writing_header_keyword(
-    expected_records: List[pysam.AlignedSegment],
+    expected_records: list[pysam.AlignedSegment],
     header_dict: AlignmentHeader,
     tmp_path: Path,
 ) -> None:
@@ -228,7 +226,7 @@ def test_invalid_cigar_element(character: str) -> None:
         ([(op.code, op.code + 1) for op in CigarOp], "1M2I3D4N5S6H7P8=9X"),  # all operators
     ],
 )
-def test_cigar_from_cigartuples(cigartuples: List[Tuple[int, int]], cigarstring: str) -> None:
+def test_cigar_from_cigartuples(cigartuples: list[tuple[int, int]], cigarstring: str) -> None:
     cigar = Cigar.from_cigartuples(cigartuples)
     assert str(cigar) == cigarstring
 

--- a/tests/fgpyo/test_read_structure.py
+++ b/tests/fgpyo/test_read_structure.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import pytest
 
 from fgpyo.read_structure import ReadSegment
@@ -56,7 +54,7 @@ def _s(off: int, length: int) -> ReadSegment:
         ),
     ],
 )
-def test_read_structure_from_string(string: str, segments: Tuple[ReadSegment, ...]) -> None:
+def test_read_structure_from_string(string: str, segments: tuple[ReadSegment, ...]) -> None:
     assert ReadStructure.from_string(segments=string).segments == segments
 
 
@@ -84,7 +82,7 @@ def test_read_structure_from_string(string: str, segments: Tuple[ReadSegment, ..
     ],
 )
 def test_read_structure_from_string_with_whitespace(
-    string: str, segments: Tuple[ReadSegment, ...]
+    string: str, segments: tuple[ReadSegment, ...]
 ) -> None:
     assert ReadStructure.from_string(segments=string).segments == segments
 
@@ -97,7 +95,7 @@ def test_read_structure_from_string_with_whitespace(
     ],
 )
 def test_read_structure_variable_once_and_only_once_last_segment_ok(
-    string: str, segments: Tuple[ReadSegment, ...]
+    string: str, segments: tuple[ReadSegment, ...]
 ) -> None:
     assert ReadStructure.from_string(segments=string).segments == segments
 
@@ -133,7 +131,7 @@ def test_read_structure_rejects_unknown_type(string: str) -> None:
     ],
 )
 def test_read_structure_from_segments_reset_offset(
-    segments: Tuple[ReadSegment, ...], expected: Tuple[ReadSegment, ...]
+    segments: tuple[ReadSegment, ...], expected: tuple[ReadSegment, ...]
 ) -> None:
     read_structure = ReadStructure.from_segments(segments=segments, reset_offsets=True)
     assert read_structure.segments == expected

--- a/tests/fgpyo/test_sequence.py
+++ b/tests/fgpyo/test_sequence.py
@@ -1,8 +1,5 @@
 """Tests for `~fgpyo.sequence`."""
 
-from typing import List
-from typing import Tuple
-
 import pytest
 
 from fgpyo.sequence import complement
@@ -167,7 +164,7 @@ def test_levenshtein_dynamic(string1: str, string2: str, levenshtein_distance: i
     assert levenshtein(string1, string2) == levenshtein_distance
 
 
-MULTINUCLEOTIDE_TEST_CASES: List[Tuple[str, int, int]] = [
+MULTINUCLEOTIDE_TEST_CASES: list[tuple[str, int, int]] = [
     ("", 2, 0),
     ("", 1, 0),
     ("A", 1, 1),
@@ -203,7 +200,7 @@ MULTINUCLEOTIDE_TEST_CASES: List[Tuple[str, int, int]] = [
     ("ttgaTtaCaGATTACAgattacacc", 7, 21),
 ]
 
-DINUCLEOTIDE_TEST_CASES: List[Tuple[str, int]] = [
+DINUCLEOTIDE_TEST_CASES: list[tuple[str, int]] = [
     (bases, expected_length)
     for bases, repeat_unit_length, expected_length in MULTINUCLEOTIDE_TEST_CASES
     if repeat_unit_length == 2

--- a/tests/fgpyo/util/test_inspect.py
+++ b/tests/fgpyo/util/test_inspect.py
@@ -1,9 +1,5 @@
 import dataclasses
-from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Set
-from typing import Tuple
 from typing import Union
 
 import attr
@@ -149,32 +145,32 @@ def test_attr_from_custom_type_without_parser_fails() -> None:
 
 
 def test_list_parser() -> None:
-    parser = list_parser(Foo, List[int], {})
+    parser = list_parser(Foo, list[int], {})
     assert parser("") == []
     assert parser("1,2,3") == [1, 2, 3]
 
 
 def test_set_parser() -> None:
-    parser = set_parser(Foo, Set[int], {})
+    parser = set_parser(Foo, set[int], {})
     assert parser("{}") == set()
     assert parser("{1,2,3}") == {1, 2, 3}
     assert parser("{1,1,2,3}") == {1, 2, 3}
 
 
 def test_tuple_parser() -> None:
-    parser = tuple_parser(Foo, Tuple[int, str], {})
+    parser = tuple_parser(Foo, tuple[int, str], {})
     assert parser("()") == ()
     assert parser("(1,a)") == (1, "a")
 
 
 def test_dict_parser() -> None:
-    parser = dict_parser(Foo, Dict[int, str], {})
+    parser = dict_parser(Foo, dict[int, str], {})
     assert parser("{}") == {}
     assert parser("{123;a}") == {123: "a"}
 
 
 def test_dict_parser_with_duplicate_keys() -> None:
-    parser = dict_parser(Foo, Dict[int, str], {})
+    parser = dict_parser(Foo, dict[int, str], {})
     with pytest.raises(ValueError):
         parser("{123;a,123;b}")
 

--- a/tests/fgpyo/util/test_metric.py
+++ b/tests/fgpyo/util/test_metric.py
@@ -6,15 +6,10 @@ import enum
 import gzip
 import os
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Set
-from typing import Tuple
-from typing import Type
 from typing import TypeAlias
 from typing import TypeVar
 
@@ -39,7 +34,7 @@ class EnumTest(enum.Enum):
     EnumVal3 = "val3"
 
 
-T = TypeVar("T", bound=Type)
+T = TypeVar("T", bound=type[Any])
 
 
 def make_dataclass(use_attr: bool = False) -> Callable[[T], T]:
@@ -94,14 +89,14 @@ class DataBuilder:
             optional_int_value: int | None
             optional_bool_value: bool | None
             optional_enum_value: EnumTest | None
-            dict_value: Dict[int, str]
-            tuple_value: Tuple[int, str]
-            list_value: List[str]
-            complex_value: Dict[
+            dict_value: dict[int, str]
+            tuple_value: tuple[int, str]
+            list_value: list[str]
+            complex_value: dict[
                 int,
-                Dict[
-                    Tuple[int, int],
-                    Set[str],
+                dict[
+                    tuple[int, int],
+                    set[str],
                 ],
             ]
 
@@ -131,7 +126,7 @@ class DataBuilder:
             age: int
 
             @classmethod
-            def _parsers(cls) -> Dict[type, Callable[[str], Any]]:
+            def _parsers(cls) -> dict[type, Callable[[str], Any]]:
                 return {Name: lambda value: Name.parse(value=value)}
 
             @classmethod
@@ -158,8 +153,8 @@ class DataBuilder:
 
         @make_dataclass(use_attr=use_attr)
         class ListPerson(Metric["ListPerson"]):
-            name: List[str | None]
-            age: List[int | None]
+            name: list[str | None]
+            age: list[int | None]
 
         self.DummyMetric = DummyMetric
         self.Person = Person
@@ -170,7 +165,7 @@ class DataBuilder:
         self.PersonDefault = PersonDefault
         self.ListPerson = ListPerson
 
-        self.DUMMY_METRICS: List[DummyMetric] = [
+        self.DUMMY_METRICS: list[DummyMetric] = [
             DummyMetric(
                 int_value=1,
                 str_value="2",
@@ -278,7 +273,7 @@ def test_metric_roundtrip(
     DummyMetric: TypeAlias = data_and_classes.DummyMetric
 
     DummyMetric.write(path, metric)
-    metrics: List[DummyMetric] = list(DummyMetric.read(path=path))
+    metrics: list[DummyMetric] = list(DummyMetric.read(path=path))
 
     assert len(metrics) == 1
     assert metrics[0] == metric
@@ -290,7 +285,7 @@ def test_metrics_roundtrip(tmp_path: Path, data_and_classes: DataBuilder) -> Non
     DummyMetric: TypeAlias = data_and_classes.DummyMetric
 
     DummyMetric.write(path, *data_and_classes.DUMMY_METRICS)
-    metrics: List[DummyMetric] = list(DummyMetric.read(path=path))
+    metrics: list[DummyMetric] = list(DummyMetric.read(path=path))
 
     assert len(metrics) == len(data_and_classes.DUMMY_METRICS)
     assert metrics == data_and_classes.DUMMY_METRICS
@@ -306,7 +301,7 @@ def test_metrics_roundtrip_gzip(tmp_path: Path, data_and_classes: DataBuilder) -
     with gzip.open(path, "r") as handle:
         handle.read(1)  # Will raise an exception if not a GZIP file.
 
-    metrics: List[DummyMetric] = list(DummyMetric.read(path=path))
+    metrics: list[DummyMetric] = list(DummyMetric.read(path=path))
 
     assert len(metrics) == len(data_and_classes.DUMMY_METRICS)
     assert metrics == data_and_classes.DUMMY_METRICS
@@ -557,7 +552,7 @@ def test_metrics_fast_concat(tmp_path: Path, data_and_classes: DataBuilder) -> N
     DummyMetric.write(path_input[2], dummy_metrics[2])
 
     Metric.fast_concat(*path_input, output=path_output)
-    metrics: List[DummyMetric] = list(DummyMetric.read(path=path_output))
+    metrics: list[DummyMetric] = list(DummyMetric.read(path=path_output))
 
     assert len(metrics) == len(dummy_metrics)
     assert metrics[0].header() == DummyMetric.header()
@@ -874,7 +869,7 @@ def test_assert_is_metric_class_raises_if_not_a_metric() -> None:
 # fmt: on
 def test_assert_fieldnames_are_metric_attributes(
     data_and_classes: DataBuilder,
-    fieldnames: List[str],
+    fieldnames: list[str],
 ) -> None:
     """Should not raise an error if the provided fieldnames are all metric attributes."""
     _assert_fieldnames_are_metric_attributes(fieldnames, data_and_classes.Person)
@@ -891,7 +886,7 @@ def test_assert_fieldnames_are_metric_attributes(
 )
 def test_assert_fieldnames_are_metric_attributes_raises(
     data_and_classes: DataBuilder,
-    fieldnames: List[str],
+    fieldnames: list[str],
 ) -> None:
     """Should raise an error if any fieldnames are not an attribute on the metric."""
     with pytest.raises(ValueError, match="One or more of the specified fields are not "):
@@ -918,7 +913,7 @@ def test_assert_file_header_matches_metric(tmp_path: Path, data_and_classes: Dat
     ],
 )
 def test_assert_file_header_matches_metric_raises(
-    tmp_path: Path, data_and_classes: DataBuilder, header: List[str]
+    tmp_path: Path, data_and_classes: DataBuilder, header: list[str]
 ) -> None:
     """Should raise an error if the provided file header does not match the provided metric."""
     metric_path = tmp_path / "metrics.tsv"
@@ -943,7 +938,7 @@ def test_metric_str_or_none(use_attr: bool, tmp_path: Path) -> None:
     ]
 
     PersonMaybeAge.write(path, *in_metrics)
-    out_metrics: List[PersonMaybeAge] = list(PersonMaybeAge.read(path=path))
+    out_metrics: list[PersonMaybeAge] = list(PersonMaybeAge.read(path=path))
 
     assert len(out_metrics) == 2
     assert out_metrics[0] == in_metrics[0]
@@ -963,5 +958,5 @@ def test_metric_multi_arg_optional_missing_column(use_attr: bool, tmp_path: Path
     with path.open("w") as writer:
         writer.write("name\nMax\n")
 
-    out_metrics: List[PersonMaybeId] = list(PersonMaybeId.read(path=path))
+    out_metrics: list[PersonMaybeId] = list(PersonMaybeId.read(path=path))
     assert out_metrics == [PersonMaybeId(name="Max", identifier=None)]

--- a/tests/fgpyo/util/test_types.py
+++ b/tests/fgpyo/util/test_types.py
@@ -1,8 +1,6 @@
-from typing import Iterable
-from typing import List
+from collections.abc import Iterable
+from collections.abc import Sequence
 from typing import Optional
-from typing import Sequence
-from typing import Type
 from typing import Union
 
 import pytest
@@ -12,7 +10,7 @@ from fgpyo.util.inspect import NoneType
 
 
 def test_is_listlike() -> None:
-    assert types.is_list_like(List[str])
+    assert types.is_list_like(list[str])
     assert types.is_list_like(Iterable[str])
     assert types.is_list_like(Sequence[str])
     assert not types.is_list_like(str)
@@ -32,7 +30,7 @@ def test_is_listlike() -> None:
         (str, False),
     ],
 )
-def test_is_optional(tpe: Type, expected: bool) -> None:
+def test_is_optional(tpe: type, expected: bool) -> None:
     assert types._is_optional(tpe) == expected
 
 

--- a/tests/fgpyo/vcf/test_builder.py
+++ b/tests/fgpyo/vcf/test_builder.py
@@ -1,13 +1,10 @@
 import gzip
 import random
+from collections.abc import Iterable
+from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import List
-from typing import Mapping
-from typing import Tuple
 
 import pysam
 import pytest
@@ -29,13 +26,13 @@ def random_generator(seed: int = 42) -> random.Random:
 
 
 @pytest.fixture(scope="function")
-def sequence_dict() -> Dict[str, Dict[str, Any]]:
+def sequence_dict() -> dict[str, dict[str, Any]]:
     return VariantBuilder.default_sd()
 
 
 def _get_random_contig(
-    random_generator: random.Random, sequence_dict: Dict[str, Dict[str, Any]]
-) -> Tuple[str, int]:
+    random_generator: random.Random, sequence_dict: dict[str, dict[str, Any]]
+) -> tuple[str, int]:
     """Randomly select a contig from the sequence dictionary and return its name and length."""
     contig = random_generator.choice(list(sequence_dict.values()))
     return contig["ID"], contig["length"]
@@ -51,7 +48,7 @@ _INFO_FIELD_TYPES = MappingProxyType({
 
 def _get_random_variant_inputs(
     random_generator: random.Random,
-    sequence_dict: Dict[str, Dict[str, Any]],
+    sequence_dict: dict[str, dict[str, Any]],
 ) -> Mapping[str, Any]:
     """Randomly generate inputs that should produce a valid Variant. Don't include format fields."""
     contig, contig_len = _get_random_contig(random_generator, sequence_dict)
@@ -99,8 +96,8 @@ def _get_random_variant_inputs(
 
 @pytest.fixture(scope="function")
 def zero_sample_record_inputs(
-    random_generator: random.Random, sequence_dict: Dict[str, Dict[str, Any]]
-) -> Tuple[Mapping[str, Any], ...]:
+    random_generator: random.Random, sequence_dict: dict[str, dict[str, Any]]
+) -> tuple[Mapping[str, Any], ...]:
     """
     Fixture with inputs to create test Variant records for zero-sample VCFs.
 
@@ -173,7 +170,7 @@ def test_minimal_inputs() -> None:
 
 def test_sort_order(random_generator: random.Random) -> None:
     """Test if the VariantBuilder sorts the Variant records in the correct order."""
-    sorted_inputs: List[Dict[str, Any]] = [
+    sorted_inputs: list[dict[str, Any]] = [
         {"contig": "chr1", "pos": 100},
         {"contig": "chr1", "pos": 500},
         {"contig": "chr2", "pos": 1000},
@@ -182,7 +179,7 @@ def test_sort_order(random_generator: random.Random) -> None:
         {"contig": "chr10", "pos": 20},
         {"contig": "chr11", "pos": 5},
     ]
-    scrambled_inputs: List[Dict[str, Any]] = random_generator.sample(
+    scrambled_inputs: list[dict[str, Any]] = random_generator.sample(
         sorted_inputs, k=len(sorted_inputs)
     )
     assert scrambled_inputs != sorted_inputs  # there should be something to actually sort
@@ -200,7 +197,7 @@ def test_sort_order(random_generator: random.Random) -> None:
 
 
 def test_zero_sample_records_match_inputs(
-    zero_sample_record_inputs: Tuple[Mapping[str, Any]],
+    zero_sample_record_inputs: tuple[Mapping[str, Any]],
 ) -> None:
     """Test if zero-sample VCF (no genotypes) records produced match the requested inputs."""
     variant_builder = VariantBuilder()
@@ -265,7 +262,7 @@ def _get_is_compressed(input_file: Path) -> bool:
 @pytest.mark.parametrize("compress", (True, False))
 def test_zero_sample_vcf_round_trip(
     temp_path: Path,
-    zero_sample_record_inputs: Tuple[Mapping[str, Any], ...],
+    zero_sample_record_inputs: tuple[Mapping[str, Any], ...],
     compress: bool,
 ) -> None:
     """Test if zero-sample VCF output records match the records read from the resulting VCF."""
@@ -336,7 +333,7 @@ def _add_random_genotypes(
 @pytest.mark.parametrize("add_genotypes_to_records", (True, False))
 def test_variant_sample_records_match_inputs(
     random_generator: random.Random,
-    zero_sample_record_inputs: Tuple[Mapping[str, Any]],
+    zero_sample_record_inputs: tuple[Mapping[str, Any]],
     num_samples: int,
     add_genotypes_to_records: bool,
 ) -> None:
@@ -377,7 +374,7 @@ def test_variant_sample_records_match_inputs(
 def test_variant_sample_vcf_round_trip(
     temp_path: Path,
     random_generator: random.Random,
-    zero_sample_record_inputs: Tuple[Mapping[str, Any]],
+    zero_sample_record_inputs: tuple[Mapping[str, Any]],
     num_samples: int,
     compress: bool,
     add_genotypes_to_records: bool,

--- a/tests/fgpyo/vcf/test_builder.py
+++ b/tests/fgpyo/vcf/test_builder.py
@@ -197,7 +197,7 @@ def test_sort_order(random_generator: random.Random) -> None:
 
 
 def test_zero_sample_records_match_inputs(
-    zero_sample_record_inputs: tuple[Mapping[str, Any]],
+    zero_sample_record_inputs: tuple[Mapping[str, Any], ...],
 ) -> None:
     """Test if zero-sample VCF (no genotypes) records produced match the requested inputs."""
     variant_builder = VariantBuilder()
@@ -333,7 +333,7 @@ def _add_random_genotypes(
 @pytest.mark.parametrize("add_genotypes_to_records", (True, False))
 def test_variant_sample_records_match_inputs(
     random_generator: random.Random,
-    zero_sample_record_inputs: tuple[Mapping[str, Any]],
+    zero_sample_record_inputs: tuple[Mapping[str, Any], ...],
     num_samples: int,
     add_genotypes_to_records: bool,
 ) -> None:
@@ -374,7 +374,7 @@ def test_variant_sample_records_match_inputs(
 def test_variant_sample_vcf_round_trip(
     temp_path: Path,
     random_generator: random.Random,
-    zero_sample_record_inputs: tuple[Mapping[str, Any]],
+    zero_sample_record_inputs: tuple[Mapping[str, Any], ...],
     num_samples: int,
     compress: bool,
     add_genotypes_to_records: bool,


### PR DESCRIPTION
## Summary

Closes #298.

Follow-up to #292 (PEP 604). Now that fgpyo requires Python 3.10+ (#261), annotation-site uses of `typing.List` / `Dict` / `Tuple` / `Set` / `FrozenSet` / `Type` migrate to the PEP 585 built-ins (`list`, `dict`, `tuple`, `set`, `frozenset`, `type`). 31 files touched.

Applied via `ruff check --select UP006,UP035 --fix --unsafe-fixes` followed by an `F401` pass to drop now-unused legacy imports. Two call sites needed manual follow-up because bare `Type` (from `typing`) was equivalent to `Type[Any]` but bare `type` (builtin) is stricter:

- `fgpyo/util/inspect.py` — `cls: type` → `cls: type[Any]` on `_get_parser`, so mypy continues to accept `cls._parsers()` on `Metric` subclasses.
- `tests/fgpyo/util/test_metric.py` — `TypeVar("T", bound=type)` → `bound=type[Any]`, keeping the decorator applicable to any class rather than just metaclasses.

**No runtime behavior changes.** `NamedTuple`, `TypeVar`, `TypeGuard`, `TypeAlias` are left as-is (no PEP 585 equivalent). Docstring/comment references to legacy forms also stay.

## Test plan

- [x] Lint, format, mypy, unit, and doctest suite pass cleanly after the sweep — no runtime behavior shifted.
- [x] Audited the files flagged by #292 (`test_types.py`, `test_inspect.py`, `test_metric.py`) for legacy-syntax coverage pairs — PEP 585 doesn't have the `Union`/`types.UnionType` split that made #292 sensitive, since `typing.get_origin(list[X])` and `get_origin(List[X])` both return `list`.
- [ ] CI passes

Co-Authored-By: Claude <noreply@anthropic.com>