### PR TITLE
chore: address Zizmor security findings in GHA workflows

### DIFF
--- a/.github/workflows/publish_fgpyo.yml
+++ b/.github/workflows/publish_fgpyo.yml
@@ -4,9 +4,13 @@ on:
   push:
     tags: '[0-9]+.[0-9]+.[0-9]+'
 
+permissions: {}
+
 jobs:
   on-main-branch-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       on_main: ${{ steps.contains_tag.outputs.retval }}
     steps:
@@ -21,6 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308  # v1.2.10
         id: contains_tag
@@ -32,22 +37,27 @@ jobs:
     name: tests
     needs: on-main-branch-check
     if: ${{ needs.on-main-branch-check.outputs.on_main == 'true' }}
+    permissions: {}
     uses: "./.github/workflows/tests.yml"
 
   build-wheels:
     name: build wheels
     needs: tests
+    permissions: {}
     uses: "./.github/workflows/wheels.yml"
 
   build-sdist:
     name: build source distribution
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -86,6 +96,8 @@ jobs:
   make-changelog:
     runs-on: ubuntu-latest
     needs: publish-to-pypi
+    permissions:
+      contents: read
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
@@ -94,6 +106,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Generate a Changelog
         uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72  # v4.7.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,13 +24,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: "${{ matrix.PYTHON_VERSION }}"
-          enable-cache: 'true'
+          enable-cache: false
           cache-suffix: "${{ matrix.PYTHON_VERSION }}"
 
       - name: Install dependencies

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,10 +8,14 @@ on:
 env:
   UV_VERSION: 0.8.22
 
+permissions: {}
+
 jobs:
   build-wheels:
     name: Build wheels for ${{ matrix.PYTHON_VERSION }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13"]
@@ -19,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0


### PR DESCRIPTION
Fixes #285

[Zizmor](https://docs.zizmor.sh/) reported 32 findings on our GitHub Actions workflows, including 2 high-severity. This closes all but one — the `pull_request_target` trigger in `readthedocs.yml`, which is owned by #283 (that PR removes the workflow entirely).

## Changes

- `persist-credentials: false` on all 5 `actions/checkout` steps (`artipacked`).
- Top-level `permissions: {}` in `publish_fgpyo.yml` and `wheels.yml`, with per-job least-privilege scoping: `contents: read` for jobs that read the repo, `permissions: {}` for the reusable-workflow callers.
- Disabled `setup-uv` cache in `tests.yml` (`cache-poisoning`). `tests.yml` is reachable via `workflow_call` from the publish flow, where a poisoned cache could affect release-gating tests.

**Existing publish/release permissions are preserved.** `id-token: write` on the PyPI publish job and `contents: write` on the GitHub release job are unchanged — only previously-implicit default permissions were tightened.

## Test plan

- Zizmor drops from 32 findings (2 high, 12 medium, 1 info) to 2: the deferred `dangerous-triggers` in `readthedocs.yml` (owned by #283) and one informational `superfluous-actions` note about `softprops/action-gh-release`.
- `actionlint` reports no issues.
- Local test + doctest suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)